### PR TITLE
Docs: Clarify project direction and standardize wording across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,17 +136,17 @@ See: `docs/design/HTTP_COMPATIBILITY.md`
 
 ---
 
-## Editions
+## Project Direction
 
-M3Undle follows an open-core model.
+The current focus is delivering a stable, fully usable self-hosted lineup manager.
 
-The current focus is delivering a stable, fully usable self-hosted lineup manager. Advanced features may be introduced in future releases.
+Advanced features may be introduced in future releases as the project matures.
 
 ---
 
 ## License
 
-Core: Apache License 2.0
+Project license: Apache License 2.0
 See `LICENSE` for details.
 
 ---
@@ -155,4 +155,4 @@ See `LICENSE` for details.
 
 **CLI:** Stable and usable.
 
-**Service + Web UI:** **Pre-Alpha** — actively building toward the Alpha checkpoint. Core concepts being proven. Not production-ready. Will change significantly.
+**Service + Web UI:** **Pre-Alpha** — actively building toward the Alpha checkpoint. Foundational concepts being proven. Not production-ready. Will change significantly.

--- a/docs/GUI.md
+++ b/docs/GUI.md
@@ -121,8 +121,8 @@ The GUI manages lineups.
 
 ---
 
-## Editions
+## Project Direction
 
-M3Undle follows an open-core model.
+The current focus is delivering a stable, fully usable self-hosted lineup manager.
 
-The current focus is delivering a stable, fully usable self-hosted lineup manager. Advanced features may be introduced in future releases.
+Advanced features may be introduced in future releases as the project matures.

--- a/docs/SERVICE.md
+++ b/docs/SERVICE.md
@@ -26,7 +26,7 @@ At a high level, the service:
 
 ---
 
-## Core Concepts (User-Facing)
+## Key Concepts (User-Facing)
 
 ### Provider
 An upstream source you configure (URL + credentials). Providers can be large and noisy.
@@ -128,7 +128,7 @@ A future release will introduce lineup shaping controls:
 ## Relationship to the CLI
 
 The CLI is a file-oriented tool for filtering large playlists.
-The service builds on the same core ideas but adds:
+The service builds on the same foundational ideas but adds:
 
 - DB-backed configuration
 - snapshot publishing
@@ -139,8 +139,8 @@ See: `CLI.md`
 
 ---
 
-## Editions Note
+## Project Direction
 
-M3Undle follows an open-core model.
 The current focus is delivering a stable, fully usable self-hosted lineup manager.
-Advanced features may be introduced in future releases.
+
+Advanced features may be introduced in future releases as the project matures.

--- a/docs/dev/ROADMAP.md
+++ b/docs/dev/ROADMAP.md
@@ -77,12 +77,12 @@ plugins load against these contracts. Do not build filtering as concrete classes
 - Endpoint security: secret token embedded in URL path
   (not headers — Media Players cannot set custom headers)
 - Token generation and rotation UI
-- Any remaining core items before Beta
+- Any remaining foundational items before Beta
 
 ---
 
 ## Beta — Feature Finalization
-**Goal:** All core functionality implemented, stable, and documented.
+**Goal:** All foundational functionality implemented, stable, and documented.
 No major feature additions after Beta entry.
 
 - New channels inbox (review and approve newly discovered channels before publishing)


### PR DESCRIPTION
### Motivation

- Refocus language away from an "Editions"/"open-core" framing toward a clear statement that the immediate goal is a stable, self-hosted lineup manager.  
- Standardize terminology around "core" vs "foundational" and clarify license and status language for consistency across docs.

### Description

- Replace the `Editions` section with a `Project Direction` section in `README.md`, `docs/GUI.md`, and `docs/SERVICE.md` and remove the explicit "M3Undle follows an open-core model." line.  
- Reword status and concept headings for clarity, including changing `Core: Apache License 2.0` to `Project license: Apache License 2.0`, `Core Concepts (User-Facing)` to `Key Concepts (User-Facing)`, and updating the service status wording to reference "foundational concepts."  
- Make small wording tweaks to align phrasing (e.g., "core ideas" -> "foundational ideas") and update the roadmap note in `docs/dev/ROADMAP.md` to reference "foundational items" before Beta.

### Testing

- No automated tests were run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e54af1048328bfe1918b38c8481c)