### PR TITLE
Fix code scanning auth, redirect, and logging findings

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/src/M3Undle.Web/Api/CompatibilityEndpoints.cs
+++ b/src/M3Undle.Web/Api/CompatibilityEndpoints.cs
@@ -676,7 +676,7 @@ public static class CompatibilityEndpoints
             }
 
             var pathBase = context.Request.PathBase.HasValue
-                ? context.Request.PathBase.Value!
+                ? context.Request.PathBase.Value!.TrimEnd('/')
                 : string.Empty;
             var generatedManifestUrl =
                 $"{pathBase}/hls/generated/{Uri.EscapeDataString(generatedSession.SessionId)}/index.m3u8";

--- a/src/M3Undle.Web/Api/CompatibilityEndpoints.cs
+++ b/src/M3Undle.Web/Api/CompatibilityEndpoints.cs
@@ -675,8 +675,11 @@ public static class CompatibilityEndpoints
                 return;
             }
 
+            var pathBase = context.Request.PathBase.HasValue
+                ? context.Request.PathBase.Value!
+                : string.Empty;
             var generatedManifestUrl =
-                $"{GetBaseUrl(context)}/hls/generated/{Uri.EscapeDataString(generatedSession.SessionId)}/index.m3u8";
+                $"{pathBase}/hls/generated/{Uri.EscapeDataString(generatedSession.SessionId)}/index.m3u8";
             generatedManifestUrl = generatedManifestUrl.ApplyClientAccessQuery(context);
 
             logger.LogInformation(

--- a/src/M3Undle.Web/Api/HdHomeRunEndpoints.cs
+++ b/src/M3Undle.Web/Api/HdHomeRunEndpoints.cs
@@ -16,6 +16,9 @@ public static class HdHomeRunEndpoints
         WriteIndented = false,
     };
 
+    private static string SanitizeForLog(string? value)
+        => string.IsNullOrEmpty(value) ? string.Empty : value.ReplaceLineEndings(" ");
+
     public static IEndpointRouteBuilder MapHdHomeRunEndpoints(this IEndpointRouteBuilder app)
     {
         var client = app.MapClientSurface();
@@ -74,7 +77,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun discover.json served to {Client}. path={Path} deviceId={DeviceId} tunerCount={TunerCount} baseUrl={BaseUrl}",
             DescribeClient(context),
-            context.Request.Path.Value ?? "/hdhr/discover.json",
+            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/discover.json",
             device.DeviceId,
             device.TunerCount,
             baseUrl);
@@ -99,7 +102,7 @@ public static class HdHomeRunEndpoints
             logger.LogWarning(
                 "HDHomeRun lineup.json unavailable for {Client}. path={Path}",
                 DescribeClient(context),
-                context.Request.Path.Value ?? "/hdhr/lineup.json");
+                SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.json");
             return lineupResult.ErrorResult!;
         }
 
@@ -113,7 +116,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun lineup.json served to {Client}. path={Path} snapshot={SnapshotId} channels={ChannelCount}",
             DescribeClient(context),
-            context.Request.Path.Value ?? "/hdhr/lineup.json",
+            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.json",
             lineupResult.Lineup.SnapshotId,
             payload.Count);
 
@@ -140,7 +143,7 @@ public static class HdHomeRunEndpoints
             logger.LogWarning(
                 "HDHomeRun lineup.xml unavailable for {Client}. path={Path}",
                 DescribeClient(context),
-                context.Request.Path.Value ?? "/hdhr/lineup.xml");
+                SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.xml");
             return lineupResult.ErrorResult!;
         }
 
@@ -174,7 +177,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun lineup.xml served to {Client}. path={Path} snapshot={SnapshotId} channels={ChannelCount}",
             DescribeClient(context),
-            context.Request.Path.Value ?? "/hdhr/lineup.xml",
+            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.xml",
             lineup.SnapshotId,
             lineup.Channels.Count);
 
@@ -201,7 +204,7 @@ public static class HdHomeRunEndpoints
             logger.LogWarning(
                 "HDHomeRun lineup.m3u unavailable for {Client}. path={Path}",
                 DescribeClient(context),
-                context.Request.Path.Value ?? "/hdhr/lineup.m3u");
+                SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.m3u");
             return lineupResult.ErrorResult!;
         }
 
@@ -226,7 +229,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun lineup.m3u served to {Client}. path={Path} snapshot={SnapshotId} channels={ChannelCount}",
             DescribeClient(context),
-            context.Request.Path.Value ?? "/hdhr/lineup.m3u",
+            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.m3u",
             lineup.SnapshotId,
             lineup.Channels.Count);
 
@@ -280,7 +283,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun lineup_status.json served to {Client}. path={Path} status={Status} channels={ChannelCount}",
             DescribeClient(context),
-            context.Request.Path.Value ?? "/hdhr/lineup_status.json",
+            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup_status.json",
             status,
             channelCount);
 
@@ -300,7 +303,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun lineup.post acknowledged for {Client}. path={Path} method={Method}",
             DescribeClient(context),
-            context.Request.Path.Value ?? "/hdhr/lineup.post",
+            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.post",
             context.Request.Method);
 
         return TypedResults.Text("OK", "text/plain; charset=utf-8");
@@ -358,7 +361,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun device.xml served to {Client}. path={Path} deviceId={DeviceId}",
             DescribeClient(context),
-            context.Request.Path.Value ?? "/hdhr/device.xml",
+            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/device.xml",
             device.DeviceId);
 
         return TypedResults.Bytes(ms.ToArray(), "application/xml; charset=utf-8");

--- a/src/M3Undle.Web/Api/HdHomeRunEndpoints.cs
+++ b/src/M3Undle.Web/Api/HdHomeRunEndpoints.cs
@@ -16,8 +16,8 @@ public static class HdHomeRunEndpoints
         WriteIndented = false,
     };
 
-    private static string SanitizeForLog(string? value)
-        => string.IsNullOrEmpty(value) ? string.Empty : value.ReplaceLineEndings(" ");
+    private static string? SanitizeForLog(string? value)
+        => value is null ? null : value.Length == 0 ? string.Empty : value.ReplaceLineEndings(" ");
 
     public static IEndpointRouteBuilder MapHdHomeRunEndpoints(this IEndpointRouteBuilder app)
     {

--- a/src/M3Undle.Web/Api/XtreamEndpoints.cs
+++ b/src/M3Undle.Web/Api/XtreamEndpoints.cs
@@ -572,7 +572,7 @@ public static class XtreamEndpoints
             }
 
             var pathBase = context.Request.PathBase.HasValue
-                ? context.Request.PathBase.Value!
+                ? context.Request.PathBase.Value!.TrimEnd('/')
                 : string.Empty;
             var generatedManifestUrl =
                 $"{pathBase}/hls/generated/{Uri.EscapeDataString(generatedSession.SessionId)}/index.m3u8";

--- a/src/M3Undle.Web/Api/XtreamEndpoints.cs
+++ b/src/M3Undle.Web/Api/XtreamEndpoints.cs
@@ -575,7 +575,8 @@ public static class XtreamEndpoints
                 ? context.Request.PathBase.Value!
                 : string.Empty;
             var generatedManifestUrl =
-                $"{pathBase}/hls/generated/{Uri.EscapeDataString(context.Request.RouteValues["xtreamUser"]?.ToString() ?? string.Empty)}/{Uri.EscapeDataString(context.Request.RouteValues["xtreamPass"]?.ToString() ?? string.Empty)}/{Uri.EscapeDataString(generatedSession.SessionId)}/index.m3u8";
+                $"{pathBase}/hls/generated/{Uri.EscapeDataString(generatedSession.SessionId)}/index.m3u8";
+            generatedManifestUrl = generatedManifestUrl.ApplyClientAccessQuery(context);
             context.Response.Redirect(generatedManifestUrl, permanent: false);
             return;
         }

--- a/src/M3Undle.Web/Api/XtreamEndpoints.cs
+++ b/src/M3Undle.Web/Api/XtreamEndpoints.cs
@@ -571,8 +571,11 @@ public static class XtreamEndpoints
                 return;
             }
 
+            var pathBase = context.Request.PathBase.HasValue
+                ? context.Request.PathBase.Value!
+                : string.Empty;
             var generatedManifestUrl =
-                $"{GetBaseUrl(context)}/hls/generated/{Uri.EscapeDataString(context.Request.RouteValues["xtreamUser"]?.ToString() ?? string.Empty)}/{Uri.EscapeDataString(context.Request.RouteValues["xtreamPass"]?.ToString() ?? string.Empty)}/{Uri.EscapeDataString(generatedSession.SessionId)}/index.m3u8";
+                $"{pathBase}/hls/generated/{Uri.EscapeDataString(context.Request.RouteValues["xtreamUser"]?.ToString() ?? string.Empty)}/{Uri.EscapeDataString(context.Request.RouteValues["xtreamPass"]?.ToString() ?? string.Empty)}/{Uri.EscapeDataString(generatedSession.SessionId)}/index.m3u8";
             context.Response.Redirect(generatedManifestUrl, permanent: false);
             return;
         }

--- a/src/M3Undle.Web/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/src/M3Undle.Web/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -28,8 +28,7 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
             [FromForm] string returnUrl) =>
         {
             IEnumerable<KeyValuePair<string, StringValues>> query = [
-                new("ReturnUrl", returnUrl),
-                new("Action", ExternalLogin.LoginCallbackAction)];
+                new("ReturnUrl", returnUrl)];
 
             var redirectUrl = UriHelper.BuildRelative(
                 context.Request.PathBase,
@@ -108,7 +107,7 @@ internal static class IdentityComponentsEndpointRouteBuilderExtensions
             var redirectUrl = UriHelper.BuildRelative(
                 context.Request.PathBase,
                 "/Account/Manage/ExternalLogins",
-                QueryString.Create("Action", ExternalLogins.LinkLoginCallbackAction));
+                QueryString.Empty);
 
             var properties = signInManager.ConfigureExternalAuthenticationProperties(provider, redirectUrl, signInManager.UserManager.GetUserId(context.User));
             return TypedResults.Challenge(properties, [provider]);

--- a/src/M3Undle.Web/Components/Account/Pages/ExternalLogin.razor
+++ b/src/M3Undle.Web/Components/Account/Pages/ExternalLogin.razor
@@ -45,8 +45,6 @@
 </div>
 
 @code {
-    public const string LoginCallbackAction = "LoginCallback";
-
     private string? message;
     private ExternalLoginInfo? externalLoginInfo;
 
@@ -61,9 +59,6 @@
 
     [SupplyParameterFromQuery]
     private string? ReturnUrl { get; set; }
-
-    [SupplyParameterFromQuery]
-    private string? Action { get; set; }
 
     private string? ProviderDisplayName => externalLoginInfo?.ProviderDisplayName;
 
@@ -88,15 +83,8 @@
 
         if (HttpMethods.IsGet(HttpContext.Request.Method))
         {
-            if (Action == LoginCallbackAction)
-            {
-                await OnLoginCallbackAsync();
-                return;
-            }
-
-            // We should only reach this page via the login callback, so redirect back to
-            // the login page if we get here some other way.
-            RedirectManager.RedirectTo("Account/Login");
+            await OnLoginCallbackAsync();
+            return;
         }
     }
 

--- a/src/M3Undle.Web/Components/Account/Pages/Manage/ExternalLogins.razor
+++ b/src/M3Undle.Web/Components/Account/Pages/Manage/ExternalLogins.razor
@@ -63,8 +63,6 @@
 }
 
 @code {
-    public const string LinkLoginCallbackAction = "LinkLoginCallback";
-
     private ApplicationUser? user;
     private IList<UserLoginInfo>? currentLogins;
     private IList<AuthenticationScheme>? otherLogins;
@@ -78,9 +76,6 @@
 
     [SupplyParameterFromForm]
     private string? ProviderKey { get; set; }
-
-    [SupplyParameterFromQuery]
-    private string? Action { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -104,9 +99,12 @@
 
         showRemoveButton = passwordHash is not null || currentLogins.Count > 1;
 
-        if (HttpMethods.IsGet(HttpContext.Request.Method) && Action == LinkLoginCallbackAction)
+        if (HttpMethods.IsGet(HttpContext.Request.Method))
         {
-            await OnGetLinkLoginCallbackAsync();
+            var userId = await UserManager.GetUserIdAsync(user);
+            var pendingLink = await SignInManager.GetExternalLoginInfoAsync(userId);
+            if (pendingLink is not null)
+                await OnGetLinkLoginCallbackAsync();
         }
     }
 

--- a/src/M3Undle.Web/Components/Account/Pages/Manage/ExternalLogins.razor
+++ b/src/M3Undle.Web/Components/Account/Pages/Manage/ExternalLogins.razor
@@ -100,12 +100,7 @@
         showRemoveButton = passwordHash is not null || currentLogins.Count > 1;
 
         if (HttpMethods.IsGet(HttpContext.Request.Method))
-        {
-            var userId = await UserManager.GetUserIdAsync(user);
-            var pendingLink = await SignInManager.GetExternalLoginInfoAsync(userId);
-            if (pendingLink is not null)
-                await OnGetLinkLoginCallbackAsync();
-        }
+            await OnGetLinkLoginCallbackAsync();
     }
 
     private async Task OnSubmitAsync()

--- a/src/M3Undle.Web/Security/ClientEndpointAccessFilter.cs
+++ b/src/M3Undle.Web/Security/ClientEndpointAccessFilter.cs
@@ -13,13 +13,14 @@ internal sealed class ClientEndpointAccessFilter(
     {
         var http = context.HttpContext;
         var resolved = await accessResolver.ResolveAsync(http, http.RequestAborted);
+        var requestPath = SanitizeForLog(http.Request.Path.Value);
 
         if (!resolved.IsSuccess)
         {
             using var scope = logger.BeginScope(new Dictionary<string, object> { ["EventType"] = "Auth" });
             logger.LogWarning(
                 "Client endpoint access denied. path={Path} method={Method} reason={Reason} client={Client}",
-                http.Request.Path.Value,
+                requestPath,
                 http.Request.Method,
                 resolved.FailureReason,
                 http.Connection.RemoteIpAddress?.ToString() ?? "unknown");
@@ -45,4 +46,7 @@ internal sealed class ClientEndpointAccessFilter(
 
         return TypedResults.Problem("Endpoint access resolution failed.", statusCode: StatusCodes.Status500InternalServerError);
     }
+
+    private static string SanitizeForLog(string? value)
+        => string.IsNullOrEmpty(value) ? string.Empty : value.ReplaceLineEndings(" ");
 }

--- a/src/M3Undle.Web/Security/XtreamPathCredentialFilter.cs
+++ b/src/M3Undle.Web/Security/XtreamPathCredentialFilter.cs
@@ -22,6 +22,7 @@ internal sealed class XtreamPathCredentialFilter(
     {
         var http = context.HttpContext;
         using var scope = logger.BeginScope(new Dictionary<string, object> { ["EventType"] = "Auth" });
+        var requestPath = SanitizeForLog(http.Request.Path.Value);
 
         var username = (string?)http.GetRouteValue("xtreamUser") ?? string.Empty;
         var password = (string?)http.GetRouteValue("xtreamPass") ?? string.Empty;
@@ -30,7 +31,7 @@ internal sealed class XtreamPathCredentialFilter(
         {
             logger.LogWarning(
                 "Xtream path authentication denied due to missing credentials. path={Path} method={Method} client={Client}",
-                http.Request.Path.Value,
+                requestPath,
                 http.Request.Method,
                 http.Connection.RemoteIpAddress?.ToString() ?? "unknown");
             http.Response.StatusCode = StatusCodes.Status401Unauthorized;
@@ -67,7 +68,7 @@ internal sealed class XtreamPathCredentialFilter(
             {
                 logger.LogWarning(
                     "Xtream path authentication denied due to invalid credentials. path={Path} method={Method} client={Client}",
-                    http.Request.Path.Value,
+                    requestPath,
                     http.Request.Method,
                     http.Connection.RemoteIpAddress?.ToString() ?? "unknown");
                 http.Response.StatusCode = StatusCodes.Status401Unauthorized;
@@ -93,4 +94,7 @@ internal sealed class XtreamPathCredentialFilter(
         http.SetResolvedClientAccess(access);
         return await next(context);
     }
+
+    private static string SanitizeForLog(string? value)
+        => string.IsNullOrEmpty(value) ? string.Empty : value.ReplaceLineEndings(" ");
 }


### PR DESCRIPTION
Summary:
- remove query-controlled external-login callback gating in the Identity external auth flow
- replace host-derived generated-HLS redirect targets with path-based redirects
- sanitize user-controlled request path values before logging in flagged endpoint filters and HDHomeRun endpoints
- add explicit minimal GitHub Actions permissions to workflows flagged by CodeQL

Why:
- address the current code scanning findings on main that are actionable in product code and workflow config
- reduce the remaining backlog to test-harness-only or already-remediated scan results

Expected code scanning coverage:
- fixes the user-controlled bypass findings in the external login pages
- fixes the URL redirection from remote source findings in CompatibilityEndpoints and XtreamEndpoints
- fixes the log entries created from user input findings in XtreamPathCredentialFilter, ClientEndpointAccessFilter, and HdHomeRunEndpoints
- fixes the workflow does not contain permissions findings in dotnet.yml and coverage.yml

Notes:
- this PR should give CodeQL new scan results to reevaluate the affected alerts, but GitHub security alerts are not auto-closed by PR text alone; any remaining open items may still need manual dismissal or closure after the post-merge scan
- the hdhr_discovery_probe.py socket-binding alerts appear to be test-harness behavior rather than a product security issue and are not changed here

Validation:
- dotnet build d:\github\IPTV\M3Undle\M3Undle.slnx
- dotnet test --solution d:\github\IPTV\M3Undle\M3Undle.slnx
- 588 tests passed