### PR TITLE
Refine route-template logging for code scanning follow-up

### DIFF
--- a/src/M3Undle.Web/Api/HdHomeRunEndpoints.cs
+++ b/src/M3Undle.Web/Api/HdHomeRunEndpoints.cs
@@ -16,8 +16,10 @@ public static class HdHomeRunEndpoints
         WriteIndented = false,
     };
 
-    private static string? SanitizeForLog(string? value)
-        => value is null ? null : value.Length == 0 ? string.Empty : value.ReplaceLineEndings(" ");
+    private static string GetRouteTemplate(HttpContext context, string fallback)
+        => context.GetEndpoint() is RouteEndpoint routeEndpoint
+            ? routeEndpoint.RoutePattern.RawText ?? fallback
+            : fallback;
 
     public static IEndpointRouteBuilder MapHdHomeRunEndpoints(this IEndpointRouteBuilder app)
     {
@@ -77,7 +79,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun discover.json served to {Client}. path={Path} deviceId={DeviceId} tunerCount={TunerCount} baseUrl={BaseUrl}",
             DescribeClient(context),
-            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/discover.json",
+            GetRouteTemplate(context, "/hdhr/discover.json"),
             device.DeviceId,
             device.TunerCount,
             baseUrl);
@@ -102,7 +104,7 @@ public static class HdHomeRunEndpoints
             logger.LogWarning(
                 "HDHomeRun lineup.json unavailable for {Client}. path={Path}",
                 DescribeClient(context),
-                SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.json");
+                GetRouteTemplate(context, "/hdhr/lineup.json"));
             return lineupResult.ErrorResult!;
         }
 
@@ -116,7 +118,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun lineup.json served to {Client}. path={Path} snapshot={SnapshotId} channels={ChannelCount}",
             DescribeClient(context),
-            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.json",
+            GetRouteTemplate(context, "/hdhr/lineup.json"),
             lineupResult.Lineup.SnapshotId,
             payload.Count);
 
@@ -143,7 +145,7 @@ public static class HdHomeRunEndpoints
             logger.LogWarning(
                 "HDHomeRun lineup.xml unavailable for {Client}. path={Path}",
                 DescribeClient(context),
-                SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.xml");
+                GetRouteTemplate(context, "/hdhr/lineup.xml"));
             return lineupResult.ErrorResult!;
         }
 
@@ -177,7 +179,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun lineup.xml served to {Client}. path={Path} snapshot={SnapshotId} channels={ChannelCount}",
             DescribeClient(context),
-            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.xml",
+            GetRouteTemplate(context, "/hdhr/lineup.xml"),
             lineup.SnapshotId,
             lineup.Channels.Count);
 
@@ -204,7 +206,7 @@ public static class HdHomeRunEndpoints
             logger.LogWarning(
                 "HDHomeRun lineup.m3u unavailable for {Client}. path={Path}",
                 DescribeClient(context),
-                SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.m3u");
+                GetRouteTemplate(context, "/hdhr/lineup.m3u"));
             return lineupResult.ErrorResult!;
         }
 
@@ -229,7 +231,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun lineup.m3u served to {Client}. path={Path} snapshot={SnapshotId} channels={ChannelCount}",
             DescribeClient(context),
-            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.m3u",
+            GetRouteTemplate(context, "/hdhr/lineup.m3u"),
             lineup.SnapshotId,
             lineup.Channels.Count);
 
@@ -283,7 +285,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun lineup_status.json served to {Client}. path={Path} status={Status} channels={ChannelCount}",
             DescribeClient(context),
-            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup_status.json",
+            GetRouteTemplate(context, "/hdhr/lineup_status.json"),
             status,
             channelCount);
 
@@ -303,7 +305,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun lineup.post acknowledged for {Client}. path={Path} method={Method}",
             DescribeClient(context),
-            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/lineup.post",
+            GetRouteTemplate(context, "/hdhr/lineup.post"),
             context.Request.Method);
 
         return TypedResults.Text("OK", "text/plain; charset=utf-8");
@@ -361,7 +363,7 @@ public static class HdHomeRunEndpoints
         logger.LogInformation(
             "HDHomeRun device.xml served to {Client}. path={Path} deviceId={DeviceId}",
             DescribeClient(context),
-            SanitizeForLog(context.Request.Path.Value) ?? "/hdhr/device.xml",
+            GetRouteTemplate(context, "/hdhr/device.xml"),
             device.DeviceId);
 
         return TypedResults.Bytes(ms.ToArray(), "application/xml; charset=utf-8");

--- a/src/M3Undle.Web/Security/ClientEndpointAccessFilter.cs
+++ b/src/M3Undle.Web/Security/ClientEndpointAccessFilter.cs
@@ -13,14 +13,14 @@ internal sealed class ClientEndpointAccessFilter(
     {
         var http = context.HttpContext;
         var resolved = await accessResolver.ResolveAsync(http, http.RequestAborted);
-        var requestPath = SanitizeForLog(http.Request.Path.Value);
+        var routeTemplate = GetRouteTemplate(http, "/client-endpoint");
 
         if (!resolved.IsSuccess)
         {
             using var scope = logger.BeginScope(new Dictionary<string, object> { ["EventType"] = "Auth" });
             logger.LogWarning(
                 "Client endpoint access denied. path={Path} method={Method} reason={Reason} client={Client}",
-                requestPath,
+                routeTemplate,
                 http.Request.Method,
                 resolved.FailureReason,
                 http.Connection.RemoteIpAddress?.ToString() ?? "unknown");
@@ -47,6 +47,8 @@ internal sealed class ClientEndpointAccessFilter(
         return TypedResults.Problem("Endpoint access resolution failed.", statusCode: StatusCodes.Status500InternalServerError);
     }
 
-    private static string SanitizeForLog(string? value)
-        => string.IsNullOrEmpty(value) ? string.Empty : value.ReplaceLineEndings(" ");
+    private static string GetRouteTemplate(HttpContext context, string fallback)
+        => context.GetEndpoint() is RouteEndpoint routeEndpoint
+            ? routeEndpoint.RoutePattern.RawText ?? fallback
+            : fallback;
 }

--- a/src/M3Undle.Web/Security/XtreamPathCredentialFilter.cs
+++ b/src/M3Undle.Web/Security/XtreamPathCredentialFilter.cs
@@ -22,7 +22,7 @@ internal sealed class XtreamPathCredentialFilter(
     {
         var http = context.HttpContext;
         using var scope = logger.BeginScope(new Dictionary<string, object> { ["EventType"] = "Auth" });
-        var requestPath = SanitizeForLog(http.Request.Path.Value);
+        var routeTemplate = GetRouteTemplate(http, "/live/{xtreamUser}/{xtreamPass}/{streamId}");
 
         var username = (string?)http.GetRouteValue("xtreamUser") ?? string.Empty;
         var password = (string?)http.GetRouteValue("xtreamPass") ?? string.Empty;
@@ -31,7 +31,7 @@ internal sealed class XtreamPathCredentialFilter(
         {
             logger.LogWarning(
                 "Xtream path authentication denied due to missing credentials. path={Path} method={Method} client={Client}",
-                requestPath,
+                routeTemplate,
                 http.Request.Method,
                 http.Connection.RemoteIpAddress?.ToString() ?? "unknown");
             http.Response.StatusCode = StatusCodes.Status401Unauthorized;
@@ -68,7 +68,7 @@ internal sealed class XtreamPathCredentialFilter(
             {
                 logger.LogWarning(
                     "Xtream path authentication denied due to invalid credentials. path={Path} method={Method} client={Client}",
-                    requestPath,
+                    routeTemplate,
                     http.Request.Method,
                     http.Connection.RemoteIpAddress?.ToString() ?? "unknown");
                 http.Response.StatusCode = StatusCodes.Status401Unauthorized;
@@ -95,6 +95,8 @@ internal sealed class XtreamPathCredentialFilter(
         return await next(context);
     }
 
-    private static string SanitizeForLog(string? value)
-        => string.IsNullOrEmpty(value) ? string.Empty : value.ReplaceLineEndings(" ");
+    private static string GetRouteTemplate(HttpContext context, string fallback)
+        => context.GetEndpoint() is RouteEndpoint routeEndpoint
+            ? routeEndpoint.RoutePattern.RawText ?? fallback
+            : fallback;
 }


### PR DESCRIPTION
Summary:
- replace remaining request-path log values with route-template based labels in the HDHomeRun and client-access filters
- keep the follow-up limited to the post-merge delta on `fix/code-scanning-main`

Why:
- PR #56 was already merged, but one additional commit was later added to the same branch
- this follow-up carries that remaining logging hardening into `main`

Scope:
- `src/M3Undle.Web/Api/HdHomeRunEndpoints.cs`
- `src/M3Undle.Web/Security/ClientEndpointAccessFilter.cs`
- `src/M3Undle.Web/Security/XtreamPathCredentialFilter.cs`

Notes:
- this PR contains the single commit currently ahead of `main` on `fix/code-scanning-main`
- branch diff vs `main`: 3 files changed, 27 insertions, 21 deletions