### PR TITLE
Fixed HLS mode not working from Smarters

### DIFF
--- a/src/M3Undle.Web/Api/XtreamEndpoints.cs
+++ b/src/M3Undle.Web/Api/XtreamEndpoints.cs
@@ -566,7 +566,7 @@ public static class XtreamEndpoints
             return;
         }
 
-        var requiresHls = PlaybackModeResolver.RequiresHls(context, forceTs);
+        var requiresHls = clientRequestedHls || PlaybackModeResolver.RequiresHls(context, forceTs);
 
         // HLS slot reservation only applies to non-shared (native upstream HLS) sessions.
         ChannelSessionManager.HlsSlotReservation? hlsSlotReservation = null;

--- a/src/M3Undle.Web/Api/XtreamEndpoints.cs
+++ b/src/M3Undle.Web/Api/XtreamEndpoints.cs
@@ -534,7 +534,9 @@ public static class XtreamEndpoints
         // the redirect path is built from trusted data and does not trigger open-redirect
         // analysis on values sourced directly from the request.
         var urlPass = access.UrlCredential?.Password;
-        if (!forceTs && resolved.UseSharedSession && PlaybackModeResolver.IsBurstBufferingClient(context)
+        var clientRequestedHls = streamId.EndsWith(".m3u8", StringComparison.OrdinalIgnoreCase);
+        if (!forceTs && resolved.UseSharedSession
+            && (clientRequestedHls || PlaybackModeResolver.IsBurstBufferingClient(context))
             && urlPass is not null)
         {
             var numericStreamId = streamId.Contains('.')

--- a/src/M3Undle.Web/Api/XtreamEndpoints.cs
+++ b/src/M3Undle.Web/Api/XtreamEndpoints.cs
@@ -545,14 +545,20 @@ public static class XtreamEndpoints
         // analysis on values sourced directly from the request.
         var urlPass = access.UrlCredential?.Password;
         var clientRequestedHls = streamId.EndsWith(".m3u8", StringComparison.OrdinalIgnoreCase);
-        if (!forceTs && resolved.UseSharedSession
+        var clientRequestedTs  = streamId.EndsWith(".ts",   StringComparison.OrdinalIgnoreCase);
+        // Don't redirect to HLS if the client explicitly requested TS — honour the extension.
+        if (!forceTs && resolved.UseSharedSession && !clientRequestedTs
             && (clientRequestedHls || PlaybackModeResolver.IsBurstBufferingClient(context))
             && urlPass is not null)
         {
             var numericStreamId = streamId.Contains('.')
                 ? streamId[..streamId.LastIndexOf('.')]
                 : streamId;
-            var hlsPath = $"/hls/{Uri.EscapeDataString(access.Credential.Username)}/{Uri.EscapeDataString(urlPass)}/{Uri.EscapeDataString(numericStreamId)}/index.m3u8";
+            // Pass the app-layer UA as a hint so the manifest handler can seed client tracking
+            // with the app identity rather than whatever the media player sends on follow-up requests.
+            var requestUa = context.Request.Headers.UserAgent.ToString();
+            var uaHint    = string.IsNullOrEmpty(requestUa) ? string.Empty : $"?_ua={Uri.EscapeDataString(requestUa)}";
+            var hlsPath = $"/hls/{Uri.EscapeDataString(access.Credential.Username)}/{Uri.EscapeDataString(urlPass)}/{Uri.EscapeDataString(numericStreamId)}/index.m3u8{uaHint}";
             logger.LogInformation(
                 "Auto-HLS redirect (Xtream): channel={Channel} id={StreamId} client={Client}",
                 entry.DisplayName, streamId, context.Connection.RemoteIpAddress);
@@ -921,12 +927,17 @@ public static class XtreamEndpoints
             return;
         }
 
+        // Prefer the UA hint seeded by the redirect (the app-layer UA from ServeXtreamStreamAsync)
+        // over whatever the media player sends on this follow-up request — the hint is more specific.
+        var hintUa      = context.Request.Query["_ua"].ToString();
+        var requestUa   = context.Request.Headers.UserAgent.ToString();
+        var effectiveUa = string.IsNullOrEmpty(hintUa) ? requestUa : hintUa;
         generatedHlsSessionManager.TrackClient(
             generatedSession.SessionId,
             context.Connection.RemoteIpAddress?.ToString(),
-            context.Request.Headers.UserAgent.ToString(),
+            effectiveUa,
             context.Request.Path.Value ?? string.Empty,
-            GeneratedHlsSessionManager.ShouldCountAsViewer(context.Request.Headers.UserAgent.ToString()));
+            GeneratedHlsSessionManager.ShouldCountAsViewer(effectiveUa));
 
         var manifest = await generatedHlsSessionManager.ReadManifestAsync(generatedSession.SessionId, cancellationToken);
         if (manifest is null)

--- a/src/M3Undle.Web/Components/Pages/Streams.razor
+++ b/src/M3Undle.Web/Components/Pages/Streams.razor
@@ -180,24 +180,29 @@ else
         <MudTable T="StreamClientSnapshot" Items="_clients" Hover="true" Dense="true" Breakpoint="Breakpoint.Sm">
             <HeaderContent>
                 <MudTh>Client</MudTh>
+                <MudTh>Channel</MudTh>
                 <MudTh>IP</MudTh>
+                <MudTh>Source</MudTh>
                 <MudTh>Delivery</MudTh>
                 <MudTh>Transfer</MudTh>
                 <MudTh>Backlog</MudTh>
                 <MudTh>Connected</MudTh>
             </HeaderContent>
             <RowTemplate>
+                @{
+                    var clientSession = _sessions.FirstOrDefault(s => s.SessionId == context.SessionId);
+                    var channelName = context.DisplayName ?? clientSession?.DisplayName;
+                    var connectionSource = ConnectionSource(context.RequestedRoute);
+                }
                 <MudTd DataLabel="Client">
-                    @{
-                        var clientSession = _sessions.FirstOrDefault(s => s.SessionId == context.SessionId);
-                        var channelName = clientSession?.DisplayName;
-                    }
                     <MudTooltip Text="@ClientTypeTooltip(context.UserAgent, context.RequestedRoute)" Placement="Placement.Right">
                         <MudText Typo="Typo.body2">@DetectClientType(context.UserAgent)</MudText>
                     </MudTooltip>
+                </MudTd>
+                <MudTd DataLabel="Channel">
                     @if (channelName is not null)
                     {
-                        <MudText Typo="Typo.caption" Color="Color.Secondary">@channelName</MudText>
+                        <MudText Typo="Typo.body2">@channelName</MudText>
                     }
                     else if (!string.IsNullOrEmpty(context.RequestedRoute))
                     {
@@ -205,11 +210,29 @@ else
                             <MudText Typo="Typo.caption" Color="Color.Secondary">@RouteSummary(context.RequestedRoute)</MudText>
                         </MudTooltip>
                     }
+                    else
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">—</MudText>
+                    }
                 </MudTd>
                 <MudTd DataLabel="IP">
                     <MudTooltip Text="@IpTooltip(context.RemoteIp)" Placement="Placement.Top">
                         <MudText Typo="Typo.body2">@(context.RemoteIp ?? "—")</MudText>
                     </MudTooltip>
+                </MudTd>
+                <MudTd DataLabel="Source">
+                    @if (connectionSource is not null)
+                    {
+                        <TooltipChip Label="@connectionSource"
+                                     TooltipText="@ConnectionSourceTooltip(connectionSource)"
+                                     Color="@ConnectionSourceColor(connectionSource)"
+                                     Variant="Variant.Outlined"
+                                     Size="Size.Small" />
+                    }
+                    else
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Secondary">—</MudText>
+                    }
                 </MudTd>
                 <MudTd DataLabel="Delivery">
                     <TooltipChip Label="@DeliveryLabel(context.Delivery)"
@@ -538,17 +561,68 @@ else
         return "Stream request";
     }
 
+    private static Color ConnectionSourceColor(string? source) => source switch
+    {
+        "Xtream" => Color.Primary,
+        "HDHomeRun" => Color.Secondary,
+        _ => Color.Default,
+    };
+
+    private static string ConnectionSourceTooltip(string? source) => source switch
+    {
+        "Xtream" => "Client connected via the Xtream Codes API.",
+        "HDHomeRun" => "Client connected via the HDHomeRun-compatible API.",
+        "M3U" => "Client connected via the M3U playlist.",
+        _ => "Connection source unknown.",
+    };
+
+    // Returns the connection protocol the client used to reach this stream.
+    // M3U compatibility routes vs Xtream API routes are distinguished by path shape:
+    //   Xtream TS  : /live/{user}/{pass}/{id}  /movie/...  /series/...
+    //   Xtream HLS : /hls/{user}/{pass}/{id}/index.m3u8
+    //   Xtream segs: /hls/generated/{user}/{pass}/{sessionId}/{asset}  (4+ segments after "generated")
+    //   M3U segs   : /hls/generated/{sessionId}/{asset}                (2 segments after "generated")
+    private static string? ConnectionSource(string? route)
+    {
+        if (string.IsNullOrEmpty(route)) return null;
+
+        if (route.StartsWith("/live/", StringComparison.OrdinalIgnoreCase)
+            || route.StartsWith("/movie/", StringComparison.OrdinalIgnoreCase)
+            || route.StartsWith("/series/", StringComparison.OrdinalIgnoreCase))
+            return "Xtream";
+
+        // /hls/{user}/{pass}/{id}/index.m3u8 — Xtream external HLS manifest
+        if (route.StartsWith("/hls/", StringComparison.OrdinalIgnoreCase)
+            && !route.StartsWith("/hls/generated/", StringComparison.OrdinalIgnoreCase))
+            return "Xtream";
+
+        if (route.StartsWith("/hls/generated/", StringComparison.OrdinalIgnoreCase))
+        {
+            var afterGenerated = route["/hls/generated/".Length..];
+            // Xtream: user/pass/sessionId/asset → 3+ slashes; M3U: sessionId/asset → 1 slash
+            return afterGenerated.Count(c => c == '/') >= 3 ? "Xtream" : "M3U";
+        }
+
+        if (route.StartsWith("/hdhr/", StringComparison.OrdinalIgnoreCase)
+            || route.StartsWith("/tune/", StringComparison.OrdinalIgnoreCase)
+            || route.StartsWith("/auto/", StringComparison.OrdinalIgnoreCase))
+            return "HDHomeRun";
+
+        return "M3U";
+    }
+
     private static string DetectClientType(string? userAgent)
     {
         if (string.IsNullOrWhiteSpace(userAgent)) return "Unknown";
 
         // Named apps — check before generic components they may use internally.
         if (userAgent.Contains("TiviMate", StringComparison.OrdinalIgnoreCase)) return "TiviMate";
-        // SmartersPro is the UA sent by IPTV Smarters Pro on Android TV.
-        if (userAgent.Contains("SmartersPro", StringComparison.OrdinalIgnoreCase)) return "Smarters Pro";
-        if (userAgent.Contains("Smarters Player", StringComparison.OrdinalIgnoreCase)) return "Smarters";
-        if (userAgent.Contains("IPTV Smarters", StringComparison.OrdinalIgnoreCase) ||
-            userAgent.Contains("IPTVSmarters", StringComparison.OrdinalIgnoreCase)) return "Smarters";
+        // IPTV Smarters sends several UA spellings across its request types: "SmartersPro"
+        // (no space) on segment pulls, "Smarters Pro" (with space) on the manifest/TS request,
+        // plus "IPTV Smarters" / "Smarters Player" on older builds. Match "Smarters" generically
+        // so no variant slips through to "Unknown", then distinguish the Pro tier.
+        if (userAgent.Contains("Smarters", StringComparison.OrdinalIgnoreCase))
+            return userAgent.Contains("Pro", StringComparison.OrdinalIgnoreCase) ? "Smarters Pro" : "Smarters";
         if (userAgent.Contains("Jellyfin", StringComparison.OrdinalIgnoreCase)) return "Jellyfin";
         if (userAgent.Contains("Emby", StringComparison.OrdinalIgnoreCase)) return "Emby";
         if (userAgent.Contains("Plex", StringComparison.OrdinalIgnoreCase)) return "Plex";

--- a/src/M3Undle.Web/Streaming/Compatibility/PlaybackModeResolver.cs
+++ b/src/M3Undle.Web/Streaming/Compatibility/PlaybackModeResolver.cs
@@ -35,6 +35,8 @@ public static class PlaybackModeResolver
             return true;
         if (userAgent.Contains("SmartersPro", StringComparison.OrdinalIgnoreCase))
             return true;
+        if (userAgent.Contains("Smarters Pro", StringComparison.OrdinalIgnoreCase))
+            return true;
         // The actual root cause is ExoPlayer/Media3's burst-then-idle buffering; match the
         // engine names directly so any player embedding it is covered, not just known apps.
         if (userAgent.Contains("ExoPlayer", StringComparison.OrdinalIgnoreCase))

--- a/src/M3Undle.Web/Streaming/GeneratedHls/GeneratedHlsSessionManager.cs
+++ b/src/M3Undle.Web/Streaming/GeneratedHls/GeneratedHlsSessionManager.cs
@@ -268,7 +268,8 @@ public sealed class GeneratedHlsSessionManager(
                 record.ClientId, record.SessionId, record.RequestedRoute,
                 record.RemoteIp, record.UserAgent, record.ConnectedUtc,
                 BytesSent: 0, QueueDepth: 0, Transport: ClientTransport.GeneratedHls,
-                Delivery: DeliveryMethod.Hls, DeliveryReason: "Generated HLS (segmented pull)"));
+                Delivery: DeliveryMethod.Hls, DeliveryReason: "Generated HLS (segmented pull)",
+                DisplayName: session.DisplayName));
         }
 
         registry.UpsertSession(session.ToSnapshot());

--- a/src/M3Undle.Web/Streaming/Observability/StreamClientSnapshot.cs
+++ b/src/M3Undle.Web/Streaming/Observability/StreamClientSnapshot.cs
@@ -36,5 +36,6 @@ public sealed record StreamClientSnapshot(
     ClientTransport Transport = ClientTransport.DirectRelay,
     long? BytesPerSecond = null,
     DeliveryMethod Delivery = DeliveryMethod.RawTs,
-    string? DeliveryReason = null);
+    string? DeliveryReason = null,
+    string? DisplayName = null);
 

--- a/src/M3Undle.Web/Streaming/Sessions/ChannelSessionManager.cs
+++ b/src/M3Undle.Web/Streaming/Sessions/ChannelSessionManager.cs
@@ -542,7 +542,8 @@ public sealed class ChannelSessionManager : IHostedService, IDisposable
             BytesSent: 0,
             QueueDepth: 0,
             Delivery: DeliveryMethod.Hls,
-            DeliveryReason: "Native HLS passthrough (upstream serves HLS)"));
+            DeliveryReason: "Native HLS passthrough (upstream serves HLS)",
+            DisplayName: slot.DisplayName));
 
         _registry.UpsertProvider(new StreamProviderSnapshot(
             SessionId: slot.SessionId,


### PR DESCRIPTION
PlaybackModeResolver — added "Smarters Pro" (with space) to the burst-buffering UA list. "SmartersPro" was there but the TV sends the spaced version.

Xtream stream handler — added .m3u8 extension detection. When a client explicitly requests .m3u8 from the Xtream path, we now route it to generated HLS regardless of UA. The UA-based detection is a best-effort heuristic; an explicit extension is a direct instruction.

Fixes #119 