### PR TITLE
Fix/roku streaming

### DIFF
--- a/src/M3Undle.Web/Api/XtreamEndpoints.cs
+++ b/src/M3Undle.Web/Api/XtreamEndpoints.cs
@@ -104,6 +104,10 @@ public static class XtreamEndpoints
             return BuildAccountInfoResult(context, access, minExpiry);
         }
 
+        // EPG actions always return an empty envelope — no lineup needed.
+        if (action is "get_short_epg" or "get_epg_info")
+            return Results.Json(new { epg_listings = Array.Empty<object>() }, JsonOptions);
+
         var lineup = await lineupRenderer.TryRenderActiveLineupAsync(
             access.Binding.ActiveProfileId, cancellationToken);
 
@@ -124,9 +128,6 @@ public static class XtreamEndpoints
             "get_vod_streams"       => BuildStreamsResult(context, form, lineup, "vod", streamIds),
             "get_series"            => BuildSeriesListResult(context, form, lineup),
             "get_series_info"       => BuildSeriesInfoResult(context, form, lineup, streamIds),
-            // Return a valid envelope with an empty listing so clients that access
-            // response.epg_listings don't throw on a bare array.
-            "get_short_epg" or "get_epg_info" => Results.Json(new { epg_listings = Array.Empty<object>() }, JsonOptions),
             _               => Results.Json(Array.Empty<object>(), JsonOptions),
         };
     }
@@ -975,7 +976,8 @@ public static class XtreamEndpoints
             context.Connection.RemoteIpAddress?.ToString(),
             effectiveUa,
             context.Request.Path.Value ?? string.Empty,
-            GeneratedHlsSessionManager.ShouldCountAsViewer(effectiveUa));
+            GeneratedHlsSessionManager.ShouldCountAsViewer(effectiveUa),
+            upgradedFromTs: string.Equals(context.Request.Query["_from"], "ts", StringComparison.Ordinal));
 
         var manifest = await generatedHlsSessionManager.ReadManifestAsync(generatedSession.SessionId, cancellationToken);
         if (manifest is null)

--- a/src/M3Undle.Web/Api/XtreamEndpoints.cs
+++ b/src/M3Undle.Web/Api/XtreamEndpoints.cs
@@ -928,7 +928,10 @@ public static class XtreamEndpoints
                 AdmissionKey: source.SessionKey,
                 InternalRelaySecret: generatedRelaySecret,
                 ParentStreamSessionId: parentStreamSessionId,
-                RequestedRoute: context.Request.Path.Value ?? "/hls/xtream/manifest"),
+                RequestedRoute: context.Request.Path.Value ?? "/hls/xtream/manifest",
+                // The redirect seeds _from=ts when a burst client (Roku) asked for .ts
+                // and was auto-upgraded to HLS — surface that in the stream monitor.
+                UpgradedFromTs: string.Equals(context.Request.Query["_from"], "ts", StringComparison.Ordinal)),
             cancellationToken);
 
         if (generatedSession is null)

--- a/src/M3Undle.Web/Api/XtreamEndpoints.cs
+++ b/src/M3Undle.Web/Api/XtreamEndpoints.cs
@@ -119,7 +119,10 @@ public static class XtreamEndpoints
             "get_vod_streams"       => BuildStreamsResult(context, form, lineup, "vod"),
             "get_series"            => BuildSeriesListResult(context, form, lineup),
             "get_series_info"       => BuildSeriesInfoResult(context, form, lineup),
-            _                       => Results.Json(Array.Empty<object>(), JsonOptions),
+            // Return a valid envelope with an empty listing so clients that access
+            // response.epg_listings don't throw on a bare array.
+            "get_short_epg" or "get_epg_info" => Results.Json(new { epg_listings = Array.Empty<object>() }, JsonOptions),
+            _               => Results.Json(Array.Empty<object>(), JsonOptions),
         };
     }
 
@@ -215,6 +218,11 @@ public static class XtreamEndpoints
                 var streamUrl = $"{baseUrl}/{segment}/{username}/{password}/{streamId}.{ext}";
                 var catId     = CategoryId(c.GroupTitle ?? "Uncategorized").ToString();
 
+                // Return stream_id as a string so Roku/Brightscript clients do not
+                // lose precision by converting the large int to a 32-bit float
+                // (e.g. 815011305 → "8.150113e+08") before embedding it in URLs.
+                var streamIdStr = streamId.ToString();
+
                 if (contentType == "live")
                 {
                     return (object)new
@@ -222,7 +230,7 @@ public static class XtreamEndpoints
                         num              = i + 1,
                         name             = c.DisplayName,
                         stream_type      = streamType,
-                        stream_id        = streamId,
+                        stream_id        = streamIdStr,
                         stream_icon      = c.LogoUrl ?? string.Empty,
                         epg_channel_id   = c.TvgId   ?? string.Empty,
                         added,
@@ -239,7 +247,7 @@ public static class XtreamEndpoints
                     num                 = i + 1,
                     name                = c.DisplayName,
                     stream_type         = streamType,
-                    stream_id           = streamId,
+                    stream_id           = streamIdStr,
                     stream_icon         = c.LogoUrl ?? string.Empty,
                     added,
                     category_id         = catId,
@@ -278,7 +286,7 @@ public static class XtreamEndpoints
                 {
                     num              = i + 1,
                     name             = g.Key,
-                    series_id        = SeriesId(g.Key),
+                    series_id        = SeriesId(g.Key).ToString(),
                     cover            = first.LogoUrl ?? string.Empty,
                     plot             = string.Empty,
                     cast             = string.Empty,
@@ -546,9 +554,13 @@ public static class XtreamEndpoints
         var urlPass = access.UrlCredential?.Password;
         var clientRequestedHls = streamId.EndsWith(".m3u8", StringComparison.OrdinalIgnoreCase);
         var clientRequestedTs  = streamId.EndsWith(".ts",   StringComparison.OrdinalIgnoreCase);
-        // Don't redirect to HLS if the client explicitly requested TS — honour the extension.
-        if (!forceTs && resolved.UseSharedSession && !clientRequestedTs
-            && (clientRequestedHls || PlaybackModeResolver.IsBurstBufferingClient(context))
+        // Burst-buffering clients (Roku, ExoPlayer, okhttp) cannot play raw MPEG-TS over HTTP,
+        // so redirect them to generated HLS even when the URL explicitly ends in .ts.
+        // For all other clients, honour the explicit .ts extension.
+        var isBurstClient = PlaybackModeResolver.IsBurstBufferingClient(context);
+        if (!forceTs && resolved.UseSharedSession
+            && (clientRequestedHls || isBurstClient)
+            && (!clientRequestedTs || isBurstClient)
             && urlPass is not null)
         {
             var numericStreamId = streamId.Contains('.')
@@ -558,7 +570,10 @@ public static class XtreamEndpoints
             // with the app identity rather than whatever the media player sends on follow-up requests.
             var requestUa = context.Request.Headers.UserAgent.ToString();
             var uaHint    = string.IsNullOrEmpty(requestUa) ? string.Empty : $"?_ua={Uri.EscapeDataString(requestUa)}";
-            var hlsPath = $"/hls/{Uri.EscapeDataString(access.Credential.Username)}/{Uri.EscapeDataString(urlPass)}/{Uri.EscapeDataString(numericStreamId)}/index.m3u8{uaHint}";
+            var fromHint  = (clientRequestedTs && isBurstClient)
+                ? (uaHint.Length > 0 ? "&_from=ts" : "?_from=ts")
+                : string.Empty;
+            var hlsPath = $"/hls/{Uri.EscapeDataString(access.Credential.Username)}/{Uri.EscapeDataString(urlPass)}/{Uri.EscapeDataString(numericStreamId)}/index.m3u8{uaHint}{fromHint}";
             logger.LogInformation(
                 "Auto-HLS redirect (Xtream): channel={Channel} id={StreamId} client={Client}",
                 entry.DisplayName, streamId, context.Connection.RemoteIpAddress);

--- a/src/M3Undle.Web/Api/XtreamEndpoints.cs
+++ b/src/M3Undle.Web/Api/XtreamEndpoints.cs
@@ -110,15 +110,20 @@ public static class XtreamEndpoints
         if (lineup is null)
             return Results.Json(Array.Empty<object>(), JsonOptions);
 
+        // Resolve the snapshot's bijective key→ID assignment once. The same assignment backs
+        // path-auth streaming (ID→key), so every ID advertised here resolves back to its channel.
+        var streamIds = streamIdCache.GetAssignment(
+            lineup.SnapshotId, lineup.Channels.Select(c => c.StreamKey)).KeyToId;
+
         return action switch
         {
             "get_live_categories"   => BuildCategoriesResult(lineup, "live"),
             "get_vod_categories"    => BuildCategoriesResult(lineup, "vod"),
             "get_series_categories" => BuildCategoriesResult(lineup, "series"),
-            "get_live_streams"      => BuildStreamsResult(context, form, lineup, "live"),
-            "get_vod_streams"       => BuildStreamsResult(context, form, lineup, "vod"),
+            "get_live_streams"      => BuildStreamsResult(context, form, lineup, "live", streamIds),
+            "get_vod_streams"       => BuildStreamsResult(context, form, lineup, "vod", streamIds),
             "get_series"            => BuildSeriesListResult(context, form, lineup),
-            "get_series_info"       => BuildSeriesInfoResult(context, form, lineup),
+            "get_series_info"       => BuildSeriesInfoResult(context, form, lineup, streamIds),
             // Return a valid envelope with an empty listing so clients that access
             // response.epg_listings don't throw on a bare array.
             "get_short_epg" or "get_epg_info" => Results.Json(new { epg_listings = Array.Empty<object>() }, JsonOptions),
@@ -189,7 +194,12 @@ public static class XtreamEndpoints
         return Results.Json(categories, JsonOptions);
     }
 
-    private static IResult BuildStreamsResult(HttpContext context, IFormCollection? form, RenderedLineup lineup, string contentType)
+    private static IResult BuildStreamsResult(
+        HttpContext context,
+        IFormCollection? form,
+        RenderedLineup lineup,
+        string contentType,
+        IReadOnlyDictionary<string, int> streamIds)
     {
         var access = context.GetResolvedClientAccess();
         var baseUrl = GetBaseUrl(context);
@@ -214,13 +224,17 @@ public static class XtreamEndpoints
         var streams = channels
             .Select((c, i) =>
             {
-                var streamId  = XtreamStreamIdCache.ToStreamId(c.StreamKey);
+                // Use the snapshot's bijective assignment (collision-free, always < 10,000,000)
+                // so the advertised ID resolves back to this exact channel and stays
+                // Brightscript-safe. Fall back to the preferred hash if a key is somehow absent.
+                var streamId  = streamIds.TryGetValue(c.StreamKey, out var assignedId)
+                    ? assignedId
+                    : XtreamStreamIdCache.ToStreamId(c.StreamKey);
                 var streamUrl = $"{baseUrl}/{segment}/{username}/{password}/{streamId}.{ext}";
                 var catId     = CategoryId(c.GroupTitle ?? "Uncategorized").ToString();
 
-                // Return stream_id as a string so Roku/Brightscript clients do not
-                // lose precision by converting the large int to a 32-bit float
-                // (e.g. 815011305 → "8.150113e+08") before embedding it in URLs.
+                // Emit stream_id as a string so Brightscript treats it verbatim rather than
+                // coercing through a 32-bit float. The ID is already < 10M, so this is plain digits.
                 var streamIdStr = streamId.ToString();
 
                 if (contentType == "live")
@@ -311,7 +325,11 @@ public static class XtreamEndpoints
     /// Returns full series info with episodes grouped by season for a given series_id,
     /// matching the standard Xtream Codes get_series_info response shape.
     /// </summary>
-    private static IResult BuildSeriesInfoResult(HttpContext context, IFormCollection? form, RenderedLineup lineup)
+    private static IResult BuildSeriesInfoResult(
+        HttpContext context,
+        IFormCollection? form,
+        RenderedLineup lineup,
+        IReadOnlyDictionary<string, int> streamIds)
     {
         var seriesIdParam = GetRequestValue(context.Request, form, "series_id");
         if (!int.TryParse(seriesIdParam, out var requestedSeriesId))
@@ -345,7 +363,9 @@ public static class XtreamEndpoints
                 episodesBySeason[seasonKey] = list;
             }
 
-            var streamId = XtreamStreamIdCache.ToStreamId(ep.StreamKey);
+            var streamId = streamIds.TryGetValue(ep.StreamKey, out var assignedId)
+                ? assignedId
+                : XtreamStreamIdCache.ToStreamId(ep.StreamKey);
             list.Add(new
             {
                 id                  = streamId.ToString(),
@@ -501,8 +521,8 @@ public static class XtreamEndpoints
             return;
         }
 
-        var streamKey = await streamIdCache.TryGetStreamKeyAsync(
-            lineup.SnapshotId, lineup.ChannelIndexPath, numericId, cancellationToken);
+        var streamKey = streamIdCache.TryGetStreamKey(
+            lineup.SnapshotId, lineup.Channels.Select(c => c.StreamKey), numericId);
 
         if (streamKey is null)
         {
@@ -868,8 +888,8 @@ public static class XtreamEndpoints
             return;
         }
 
-        var streamKey = await streamIdCache.TryGetStreamKeyAsync(
-            lineup.SnapshotId, lineup.ChannelIndexPath, numericId, cancellationToken);
+        var streamKey = streamIdCache.TryGetStreamKey(
+            lineup.SnapshotId, lineup.Channels.Select(c => c.StreamKey), numericId);
         if (streamKey is null)
         {
             context.Response.StatusCode = StatusCodes.Status404NotFound;

--- a/src/M3Undle.Web/Application/XtreamStreamIdCache.cs
+++ b/src/M3Undle.Web/Application/XtreamStreamIdCache.cs
@@ -4,81 +4,174 @@ using System.Text;
 namespace M3Undle.Web.Application;
 
 /// <summary>
-/// Singleton that maintains a per-snapshot mapping between Xtream numeric stream IDs
-/// (a stable 23-bit value derived from MD5(streamKey)) and the actual stream keys used by M3Undle's
-/// channel index. Invalidated automatically when the active snapshot changes.
+/// Singleton that maintains a per-snapshot <b>bijective</b> mapping between Xtream numeric
+/// stream IDs and the stream keys used by M3Undle's channel index. Invalidated automatically
+/// when the active snapshot changes.
+///
+/// <para>
+/// Stream IDs must satisfy two independent client constraints <b>at the same time</b>:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <b>Android TV / NextPVR (standard Xtream clients):</b> every ID advertised by
+///     <c>player_api</c> must resolve back to its own channel. The ID↔key mapping has to be a
+///     collision-free bijection, otherwise some channels become unreachable (their ID maps to a
+///     different channel) — which is exactly what tanked NextPVR playback.
+///   </item>
+///   <item>
+///     <b>Roku / Brightscript:</b> IDs are handled as 32-bit floats and render in scientific
+///     notation once they reach 1e7 (e.g. <c>"8.150113e+08"</c>), corrupting the stream URL.
+///     IDs must therefore stay below 10,000,000 so they always format as plain digits.
+///   </item>
+/// </list>
+///
+/// <para>
+/// A raw MD5 hash satisfies neither constraint alone: a 31-bit hash exceeds 1e7 (breaks Roku),
+/// while masking it below 1e7 collides for large lineups (breaks Android TV). We resolve both by
+/// hashing into the sub-1e7 space and then linear-probing to the next free slot, yielding a
+/// mapping that is collision-free <i>and</i> Brightscript-safe.
+/// </para>
 /// </summary>
 public sealed class XtreamStreamIdCache(ILogger<XtreamStreamIdCache> logger)
 {
-    private string? _cachedSnapshotId;
-    private Dictionary<int, string>? _idToKey;
-    private readonly SemaphoreSlim _lock = new(1, 1);
+    /// <summary>
+    /// Largest stream ID we will ever emit — one below 10,000,000 — so every ID renders as a
+    /// plain integer in Brightscript rather than scientific notation. Also the size of the
+    /// addressable ID space ([1, <see cref="MaxStreamId"/>]).
+    /// </summary>
+    public const int MaxStreamId = 9_999_999;
+
+    private readonly object _gate = new();
+    private volatile CachedAssignment? _cache;
+
+    private sealed record CachedAssignment(string SnapshotId, StreamIdAssignment Assignment);
 
     /// <summary>
-    /// Computes a stable 23-bit numeric stream ID from a stream key using MD5.
-    /// Capped at 23 bits (max 8,388,607, always below 10M) so Brightscript renders it
-    /// as plain digits rather than scientific notation when building stream URLs.
+    /// Computes the <i>preferred</i> (pre-collision-resolution) stream ID for a key: a stable
+    /// value in the range [1, <see cref="MaxStreamId"/>] derived from MD5(streamKey). The final
+    /// assigned ID can differ if this slot is already taken — see <see cref="BuildAssignment"/>.
     /// </summary>
     public static int ToStreamId(string streamKey)
     {
-        var bytes = Encoding.UTF8.GetBytes(streamKey);
-        var hash = MD5.HashData(bytes);
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes(streamKey));
         var value = BitConverter.ToUInt32(hash, 0);
-        // Mask to 23 bits (max 8,388,607) so the ID is always below 10,000,000.
-        // Brightscript renders floats >= 1e7 as scientific notation (e.g. "1.618042e+07"),
-        // which breaks URL construction. Keeping IDs < 10M ensures plain-integer formatting.
-        return (int)(value & 0x007F_FFFF);
+        // Map into [1, MaxStreamId] so the ID is always >= 1 and < 10,000,000.
+        return (int)(value % MaxStreamId) + 1;
     }
 
     /// <summary>
-    /// Looks up the stream key for a given numeric Xtream stream ID.
-    /// Returns <c>null</c> if the ID is not present in the current snapshot.
+    /// Computes the legacy 31-bit stream ID a key had before IDs were capped below 10,000,000.
+    /// Used only for <b>backward-compatible resolution</b>: clients (NextPVR, Jellyfin, Smarters)
+    /// cache their channel list and keep requesting these old IDs until they re-pull. We never
+    /// advertise them again, but we still resolve them so cached clients keep working.
     /// </summary>
-    public async Task<string?> TryGetStreamKeyAsync(
-        string snapshotId,
-        string ndjsonPath,
-        int streamId,
-        CancellationToken cancellationToken)
+    public static int ToLegacyStreamId(string streamKey)
     {
-        var map = await GetOrBuildMapAsync(snapshotId, ndjsonPath, cancellationToken);
-        return map.TryGetValue(streamId, out var key) ? key : null;
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes(streamKey));
+        var value = BitConverter.ToUInt32(hash, 0);
+        return (int)(value & 0x7FFF_FFFF);
     }
 
-    private async Task<Dictionary<int, string>> GetOrBuildMapAsync(
-        string snapshotId,
-        string ndjsonPath,
-        CancellationToken cancellationToken)
+    /// <summary>
+    /// Builds a collision-free, Brightscript-safe bijection between stream keys and numeric IDs.
+    /// Each key prefers <see cref="ToStreamId"/>; on a clash the next free slot (wrapping within
+    /// [1, <see cref="MaxStreamId"/>]) is taken. Keys are processed in a deterministic order so the
+    /// assignment is reproducible for a given set of keys.
+    ///
+    /// <para>
+    /// A secondary <see cref="StreamIdAssignment.LegacyIdToKey"/> map is also built so that IDs
+    /// cached by clients before the cap (which are &gt; <see cref="MaxStreamId"/>) still resolve.
+    /// Only legacy IDs above the cap are bridged — they can never collide with a current ID, so the
+    /// bridge is unambiguous — while current IDs always take precedence.
+    /// </para>
+    /// </summary>
+    public static StreamIdAssignment BuildAssignment(IEnumerable<string> streamKeys)
     {
-        if (_cachedSnapshotId == snapshotId && _idToKey is { } warm)
-            return warm;
+        var idToKey = new Dictionary<int, string>();
+        var keyToId = new Dictionary<string, int>(StringComparer.Ordinal);
+        var legacyIdToKey = new Dictionary<int, string>();
 
-        await _lock.WaitAsync(cancellationToken);
-        try
+        foreach (var key in streamKeys
+                     .Where(static k => !string.IsNullOrEmpty(k))
+                     .Distinct(StringComparer.Ordinal)
+                     .OrderBy(static k => k, StringComparer.Ordinal))
         {
-            if (_cachedSnapshotId == snapshotId && _idToKey is { } cached)
-                return cached;
-
-            var map = new Dictionary<int, string>();
-            await foreach (var entry in ChannelIndexStore.StreamAllAsync(ndjsonPath, cancellationToken))
+            var id = ToStreamId(key);
+            var probes = 0;
+            while (!idToKey.TryAdd(id, key))
             {
-                var id = ToStreamId(entry.StreamKey);
-                if (!map.TryAdd(id, entry.StreamKey))
-                {
-                    logger.LogWarning(
-                        "Xtream stream ID collision detected: id={StreamId} existingStreamKey={ExistingStreamKey} droppedStreamKey={DroppedStreamKey}.",
-                        id,
-                        map[id],
-                        entry.StreamKey);
-                }
+                id = id == MaxStreamId ? 1 : id + 1;
+                if (++probes > MaxStreamId)
+                    throw new InvalidOperationException(
+                        "Xtream stream ID space exhausted; the lineup exceeds the addressable ID range.");
             }
 
-            _idToKey = map;
-            _cachedSnapshotId = snapshotId;
-            return map;
+            keyToId[key] = id;
+
+            // Bridge only legacy IDs above the cap: they are disjoint from current IDs, so there is
+            // no ambiguity. (Legacy IDs that already fell below the cap are indistinguishable from
+            // current IDs and are intentionally not bridged.)
+            var legacyId = ToLegacyStreamId(key);
+            if (legacyId > MaxStreamId)
+                legacyIdToKey.TryAdd(legacyId, key);
         }
-        finally
+
+        return new StreamIdAssignment(idToKey, keyToId, legacyIdToKey);
+    }
+
+    /// <summary>
+    /// Returns the (cached) bijective ID assignment for a snapshot, built from the rendered
+    /// lineup's stream keys. Both the <c>player_api</c> listing (key → ID) and path-auth streaming
+    /// (ID → key) call this with the same snapshot lineup, so the IDs they advertise and resolve
+    /// always agree. The assignment is rebuilt only when the active snapshot changes.
+    /// </summary>
+    public StreamIdAssignment GetAssignment(string snapshotId, IEnumerable<string> streamKeys)
+    {
+        var snapshot = _cache;
+        if (snapshot is not null && snapshot.SnapshotId == snapshotId)
+            return snapshot.Assignment;
+
+        lock (_gate)
         {
-            _lock.Release();
+            snapshot = _cache;
+            if (snapshot is not null && snapshot.SnapshotId == snapshotId)
+                return snapshot.Assignment;
+
+            var assignment = BuildAssignment(streamKeys);
+
+            var relocated = assignment.KeyToId.Count(kv => ToStreamId(kv.Key) != kv.Value);
+            logger.LogInformation(
+                "Xtream stream ID assignment built for snapshot {SnapshotId}: {Channels} channels, {Relocated} relocated to keep IDs unique and below {Max}.",
+                snapshotId,
+                assignment.KeyToId.Count,
+                relocated,
+                MaxStreamId);
+
+            _cache = new CachedAssignment(snapshotId, assignment);
+            return assignment;
         }
     }
+
+    /// <summary>
+    /// Looks up the stream key for a given numeric Xtream stream ID within the snapshot lineup.
+    /// Current IDs resolve first; a legacy (pre-cap) ID still cached by a client resolves via the
+    /// backward-compatibility bridge. Returns <c>null</c> if the ID is not present.
+    /// </summary>
+    public string? TryGetStreamKey(string snapshotId, IEnumerable<string> streamKeys, int streamId)
+    {
+        var assignment = GetAssignment(snapshotId, streamKeys);
+        return assignment.IdToKey.GetValueOrDefault(streamId)
+            ?? assignment.LegacyIdToKey.GetValueOrDefault(streamId);
+    }
 }
+
+/// <summary>
+/// A collision-free, Brightscript-safe bijection between channel stream keys and numeric Xtream
+/// stream IDs for a single snapshot. <paramref name="LegacyIdToKey"/> additionally maps pre-cap
+/// (&gt; <see cref="XtreamStreamIdCache.MaxStreamId"/>) IDs back to their keys so clients that
+/// cached the old IDs keep resolving until they re-pull; it is never used for advertisement.
+/// </summary>
+public sealed record StreamIdAssignment(
+    IReadOnlyDictionary<int, string> IdToKey,
+    IReadOnlyDictionary<string, int> KeyToId,
+    IReadOnlyDictionary<int, string> LegacyIdToKey);

--- a/src/M3Undle.Web/Application/XtreamStreamIdCache.cs
+++ b/src/M3Undle.Web/Application/XtreamStreamIdCache.cs
@@ -5,7 +5,7 @@ namespace M3Undle.Web.Application;
 
 /// <summary>
 /// Singleton that maintains a per-snapshot mapping between Xtream numeric stream IDs
-/// (a stable 31-bit value derived from MD5(streamKey)) and the actual stream keys used by M3Undle's
+/// (a stable 23-bit value derived from MD5(streamKey)) and the actual stream keys used by M3Undle's
 /// channel index. Invalidated automatically when the active snapshot changes.
 /// </summary>
 public sealed class XtreamStreamIdCache(ILogger<XtreamStreamIdCache> logger)
@@ -15,15 +15,19 @@ public sealed class XtreamStreamIdCache(ILogger<XtreamStreamIdCache> logger)
     private readonly SemaphoreSlim _lock = new(1, 1);
 
     /// <summary>
-    /// Computes a stable 31-bit numeric stream ID from a stream key using MD5.
-    /// The sign bit is masked off so the value is always a positive <see cref="int"/>.
+    /// Computes a stable 23-bit numeric stream ID from a stream key using MD5.
+    /// Capped at 23 bits (max 8,388,607, always below 10M) so Brightscript renders it
+    /// as plain digits rather than scientific notation when building stream URLs.
     /// </summary>
     public static int ToStreamId(string streamKey)
     {
         var bytes = Encoding.UTF8.GetBytes(streamKey);
         var hash = MD5.HashData(bytes);
         var value = BitConverter.ToUInt32(hash, 0);
-        return (int)(value & 0x7FFF_FFFF);
+        // Mask to 23 bits (max 8,388,607) so the ID is always below 10,000,000.
+        // Brightscript renders floats >= 1e7 as scientific notation (e.g. "1.618042e+07"),
+        // which breaks URL construction. Keeping IDs < 10M ensures plain-integer formatting.
+        return (int)(value & 0x007F_FFFF);
     }
 
     /// <summary>

--- a/src/M3Undle.Web/Components/Pages/Streams.razor
+++ b/src/M3Undle.Web/Components/Pages/Streams.razor
@@ -237,17 +237,9 @@ else
                 <MudTd DataLabel="Delivery">
                     <TooltipChip Label="@DeliveryLabel(context.Delivery)"
                                  TooltipText="@DeliveryTooltip(context)"
-                                 Color="Color.Info"
+                                 Color="@(context.UpgradedFromTs ? Color.Tertiary : Color.Info)"
                                  Variant="Variant.Outlined"
                                  Size="Size.Small" />
-                    @if (IsTsUpgradedToHls(context.RequestedRoute))
-                    {
-                        <TooltipChip Label="HLS"
-                                     TooltipText="Client requested MPEG-TS but was automatically upgraded to HLS for playback compatibility."
-                                     Color="Color.Tertiary"
-                                     Variant="Variant.Outlined"
-                                     Size="Size.Small" />
-                    }
                 </MudTd>
                 <MudTd DataLabel="Transfer">
                     @if (context.Transport == ClientTransport.GeneratedHls)
@@ -684,13 +676,13 @@ else
     private static string DeliveryTooltip(StreamClientSnapshot client)
     {
         var label = DeliveryLabel(client.Delivery);
-        return string.IsNullOrWhiteSpace(client.DeliveryReason)
+        var baseText = string.IsNullOrWhiteSpace(client.DeliveryReason)
             ? $"Delivery method for this client: {label}."
             : $"Delivery method for this client: {label} — {client.DeliveryReason}.";
+        return client.UpgradedFromTs
+            ? $"{baseText} Client requested MPEG-TS but was automatically upgraded to HLS for playback compatibility."
+            : baseText;
     }
-
-    private static bool IsTsUpgradedToHls(string? route) =>
-        route is not null && route.Contains("_from=ts", StringComparison.Ordinal);
 
     private static string FormatRate(long? bytesPerSecond) => bytesPerSecond switch
     {

--- a/src/M3Undle.Web/Components/Pages/Streams.razor
+++ b/src/M3Undle.Web/Components/Pages/Streams.razor
@@ -240,6 +240,14 @@ else
                                  Color="Color.Info"
                                  Variant="Variant.Outlined"
                                  Size="Size.Small" />
+                    @if (IsTsUpgradedToHls(context.RequestedRoute))
+                    {
+                        <TooltipChip Label="HLS"
+                                     TooltipText="Client requested MPEG-TS but was automatically upgraded to HLS for playback compatibility."
+                                     Color="Color.Tertiary"
+                                     Variant="Variant.Outlined"
+                                     Size="Size.Small" />
+                    }
                 </MudTd>
                 <MudTd DataLabel="Transfer">
                     @if (context.Transport == ClientTransport.GeneratedHls)
@@ -680,6 +688,9 @@ else
             ? $"Delivery method for this client: {label}."
             : $"Delivery method for this client: {label} — {client.DeliveryReason}.";
     }
+
+    private static bool IsTsUpgradedToHls(string? route) =>
+        route is not null && route.Contains("_from=ts", StringComparison.Ordinal);
 
     private static string FormatRate(long? bytesPerSecond) => bytesPerSecond switch
     {

--- a/src/M3Undle.Web/Program.cs
+++ b/src/M3Undle.Web/Program.cs
@@ -459,6 +459,23 @@ app.Use(static async (ctx, next) =>
 });
 
 app.UseRouting();
+
+// Temporary: log every inbound request so we can see the exact URLs a Roku/unknown
+// client sends when tuning, including paths that 404 before reaching a handler.
+app.Use(static async (ctx, next) =>
+{
+    var logger = ctx.RequestServices.GetRequiredService<ILoggerFactory>()
+        .CreateLogger("M3Undle.RequestTrace");
+    var ip = ctx.Connection.RemoteIpAddress?.ToString() ?? "?";
+    logger.LogInformation("REQ {Method} {Path}{Query} from {IP} ua={UA}",
+        ctx.Request.Method,
+        ctx.Request.Path,
+        ctx.Request.QueryString,
+        ip,
+        ctx.Request.Headers.UserAgent.ToString());
+    await next(ctx);
+});
+
 app.UseRateLimiter();
 app.UseMiddleware<MetricsEndpointSecurityMiddleware>();
 app.UseOpenTelemetryPrometheusScrapingEndpoint(context =>

--- a/src/M3Undle.Web/Program.cs
+++ b/src/M3Undle.Web/Program.cs
@@ -460,22 +460,6 @@ app.Use(static async (ctx, next) =>
 
 app.UseRouting();
 
-// Temporary: log every inbound request so we can see the exact URLs a Roku/unknown
-// client sends when tuning, including paths that 404 before reaching a handler.
-app.Use(static async (ctx, next) =>
-{
-    var logger = ctx.RequestServices.GetRequiredService<ILoggerFactory>()
-        .CreateLogger("M3Undle.RequestTrace");
-    var ip = ctx.Connection.RemoteIpAddress?.ToString() ?? "?";
-    logger.LogInformation("REQ {Method} {Path}{Query} from {IP} ua={UA}",
-        ctx.Request.Method,
-        ctx.Request.Path,
-        ctx.Request.QueryString,
-        ip,
-        ctx.Request.Headers.UserAgent.ToString());
-    await next(ctx);
-});
-
 app.UseRateLimiter();
 app.UseMiddleware<MetricsEndpointSecurityMiddleware>();
 app.UseOpenTelemetryPrometheusScrapingEndpoint(context =>

--- a/src/M3Undle.Web/Streaming/GeneratedHls/GeneratedHlsSessionManager.cs
+++ b/src/M3Undle.Web/Streaming/GeneratedHls/GeneratedHlsSessionManager.cs
@@ -21,7 +21,8 @@ public sealed record GeneratedHlsSessionRequest(
     ChannelSessionKey? AdmissionKey = null,
     string? InternalRelaySecret = null,
     string? ParentStreamSessionId = null,
-    string? RequestedRoute = null);
+    string? RequestedRoute = null,
+    bool UpgradedFromTs = false);
 
 public sealed record GeneratedHlsSessionHandle(
     string SessionId,
@@ -120,7 +121,8 @@ public sealed class GeneratedHlsSessionManager(
             process,
             request.AdmissionKey,
             request.ParentStreamSessionId,
-            request.RequestedRoute);
+            request.RequestedRoute,
+            request.UpgradedFromTs);
 
         if (!_sessions.TryAdd(sessionId, session))
         {
@@ -269,7 +271,8 @@ public sealed class GeneratedHlsSessionManager(
                 record.RemoteIp, record.UserAgent, record.ConnectedUtc,
                 BytesSent: 0, QueueDepth: 0, Transport: ClientTransport.GeneratedHls,
                 Delivery: DeliveryMethod.Hls, DeliveryReason: "Generated HLS (segmented pull)",
-                DisplayName: session.DisplayName));
+                DisplayName: session.DisplayName,
+                UpgradedFromTs: session.UpgradedFromTs));
         }
 
         registry.UpsertSession(session.ToSnapshot());
@@ -1080,7 +1083,8 @@ public sealed class GeneratedHlsSessionManager(
         Process process,
         ChannelSessionKey? admissionKey = null,
         string? parentStreamSessionId = null,
-        string? requestedRoute = null)
+        string? requestedRoute = null,
+        bool upgradedFromTs = false)
     {
         private long _lastAccessUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         private Task? _stderrPumpTask;
@@ -1106,6 +1110,10 @@ public sealed class GeneratedHlsSessionManager(
         public string? ParentStreamSessionId { get; } = parentStreamSessionId;
 
         public string? RequestedRoute { get; } = requestedRoute;
+
+        // True when this session was created because a burst-buffering client (e.g. Roku)
+        // requested an MPEG-TS URL and was auto-upgraded to generated HLS.
+        public bool UpgradedFromTs { get; } = upgradedFromTs;
 
         public DateTimeOffset StartedUtc { get; } = DateTimeOffset.UtcNow;
 

--- a/src/M3Undle.Web/Streaming/GeneratedHls/GeneratedHlsSessionManager.cs
+++ b/src/M3Undle.Web/Streaming/GeneratedHls/GeneratedHlsSessionManager.cs
@@ -257,7 +257,8 @@ public sealed class GeneratedHlsSessionManager(
         string? remoteIp,
         string? userAgent,
         string requestedRoute,
-        bool countAsViewer = true)
+        bool countAsViewer = true,
+        bool upgradedFromTs = false)
     {
         if (!_sessions.TryGetValue(sessionId, out var session))
             return;
@@ -272,7 +273,7 @@ public sealed class GeneratedHlsSessionManager(
                 BytesSent: 0, QueueDepth: 0, Transport: ClientTransport.GeneratedHls,
                 Delivery: DeliveryMethod.Hls, DeliveryReason: "Generated HLS (segmented pull)",
                 DisplayName: session.DisplayName,
-                UpgradedFromTs: session.UpgradedFromTs));
+                UpgradedFromTs: upgradedFromTs));
         }
 
         registry.UpsertSession(session.ToSnapshot());

--- a/src/M3Undle.Web/Streaming/Observability/StreamClientSnapshot.cs
+++ b/src/M3Undle.Web/Streaming/Observability/StreamClientSnapshot.cs
@@ -37,5 +37,6 @@ public sealed record StreamClientSnapshot(
     long? BytesPerSecond = null,
     DeliveryMethod Delivery = DeliveryMethod.RawTs,
     string? DeliveryReason = null,
-    string? DisplayName = null);
+    string? DisplayName = null,
+    bool UpgradedFromTs = false);
 

--- a/tests/M3Undle.Web.Tests/Application/XtreamStreamIdCacheTests.cs
+++ b/tests/M3Undle.Web.Tests/Application/XtreamStreamIdCacheTests.cs
@@ -1,0 +1,193 @@
+using System.Security.Cryptography;
+using System.Text;
+using M3Undle.Web.Application;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace M3Undle.Web.Tests.Application;
+
+/// <summary>
+/// Xtream stream IDs must work for two clients with conflicting constraints at once:
+///   * Android TV / NextPVR (and IPTV Smarters): every advertised ID must resolve back to its
+///     own channel — the mapping must be a collision-free bijection.
+///   * Roku / Brightscript: IDs render in scientific notation once they hit 1e7, so they must
+///     stay below 10,000,000 to format as plain digits inside stream URLs.
+///
+/// These tests first pin the two regressions we actually shipped (a 31-bit hash broke Roku; a
+/// 23-bit hash broke the Android TV / NextPVR / Smarters path via collisions), then prove the
+/// current assignment satisfies <b>both</b> at once.
+/// </summary>
+[TestClass]
+public sealed class XtreamStreamIdCacheTests
+{
+    // At/above this value Brightscript renders a number it parsed as a float in scientific
+    // notation (e.g. "1E+07"), which corrupts the stream URL. IDs must stay strictly below it.
+    private const int BrightscriptScientificThreshold = 10_000_000;
+
+    private static List<string> GenerateKeys(int count)
+    {
+        var keys = new List<string>(count);
+        for (var i = 0; i < count; i++)
+            keys.Add($"stream-key-{i:D7}");
+        return keys;
+    }
+
+    private static int LegacyThirtyOneBitId(string key)
+    {
+        var value = BitConverter.ToUInt32(MD5.HashData(Encoding.UTF8.GetBytes(key)), 0);
+        return (int)(value & 0x7FFF_FFFF);
+    }
+
+    private static int LegacyTwentyThreeBitId(string key)
+    {
+        var value = BitConverter.ToUInt32(MD5.HashData(Encoding.UTF8.GetBytes(key)), 0);
+        return (int)(value & 0x007F_FFFF);
+    }
+
+    // ---- Failure mode 1: Roku, broken by the original 31-bit IDs --------------------------
+
+    [TestMethod]
+    public void Legacy31BitIds_BreakRoku_BecauseTheyExceedTheScientificNotationThreshold()
+    {
+        var keys = GenerateKeys(20_000);
+
+        var offenders = keys
+            .Select(LegacyThirtyOneBitId)
+            .Where(id => id >= BrightscriptScientificThreshold)
+            .ToList();
+
+        // The 31-bit scheme routinely produces IDs at/above 1e7 (e.g. WCBS = 815011305), which Roku
+        // renders as scientific notation, corrupting the .ts URL.
+        Assert.IsTrue(offenders.Count > 0,
+            "Expected 31-bit IDs to reach Roku's scientific-notation threshold (>= 1e7).");
+    }
+
+    // ---- Failure mode 2: Android TV / NextPVR / Smarters, broken by 23-bit collisions ------
+
+    [TestMethod]
+    public void Legacy23BitIds_BreakAndroidTvAndSmarters_BecauseCollisionsDropChannels()
+    {
+        var keys = GenerateKeys(50_000);
+
+        var distinctIds = keys.Select(LegacyTwentyThreeBitId).Distinct().Count();
+
+        // Fewer distinct IDs than channels means some channels share an ID: the resolver keeps
+        // only one, so the others become unreachable for every standard Xtream client.
+        Assert.IsTrue(distinctIds < keys.Count,
+            $"Expected 23-bit hashing to collide. distinctIds={distinctIds} keys={keys.Count}");
+    }
+
+    // ---- The fix: one scheme that satisfies both clients ----------------------------------
+
+    [TestMethod]
+    public void BuildAssignment_IsRokuSafe_AllIdsStayBelowTheScientificNotationThreshold()
+    {
+        var keys = GenerateKeys(50_000);
+
+        var assignment = XtreamStreamIdCache.BuildAssignment(keys);
+
+        foreach (var id in assignment.IdToKey.Keys)
+        {
+            Assert.IsTrue(id >= 1 && id <= XtreamStreamIdCache.MaxStreamId,
+                $"ID {id} is outside the Brightscript-safe range [1, {XtreamStreamIdCache.MaxStreamId}].");
+            Assert.IsTrue(id < BrightscriptScientificThreshold,
+                $"ID {id} reaches the Brightscript scientific-notation threshold and would break the Roku URL.");
+        }
+    }
+
+    [TestMethod]
+    public void BuildAssignment_IsAndroidTvSafe_IsACollisionFreeBijection_EveryChannelRoundTrips()
+    {
+        var keys = GenerateKeys(50_000);
+
+        var assignment = XtreamStreamIdCache.BuildAssignment(keys);
+
+        // No channel is dropped and no two channels share an ID.
+        Assert.AreEqual(keys.Count, assignment.KeyToId.Count, "Some channels were dropped from the assignment.");
+        Assert.AreEqual(assignment.KeyToId.Count, assignment.IdToKey.Count, "Two channels collided onto one ID.");
+
+        // Every ID advertised by player_api (key -> id) resolves back to that same channel
+        // (id -> key) — the property that NextPVR/Smarters/Jellyfin rely on to tune.
+        foreach (var (key, id) in assignment.KeyToId)
+            Assert.AreEqual(key, assignment.IdToKey[id], $"ID {id} did not resolve back to its own channel.");
+    }
+
+    [TestMethod]
+    public void BuildAssignment_IsDeterministic_RegardlessOfInputOrder()
+    {
+        var keys = GenerateKeys(5_000);
+        var reversed = Enumerable.Reverse(keys).ToList();
+
+        var first = XtreamStreamIdCache.BuildAssignment(keys);
+        var second = XtreamStreamIdCache.BuildAssignment(reversed);
+
+        CollectionAssert.AreEquivalent(
+            first.KeyToId.ToList(),
+            second.KeyToId.ToList(),
+            "Assignment must not depend on channel enumeration order.");
+    }
+
+    [TestMethod]
+    public void BuildAssignment_RegressionForWcbs_IsBelowTenMillion_AndNotTheBroken31BitId()
+    {
+        // The real key that broke playback on toontown-tv-srv1.
+        const string wcbsKey = "hu4q9YO4P3veelAx";
+
+        var assignment = XtreamStreamIdCache.BuildAssignment([wcbsKey]);
+        var id = assignment.KeyToId[wcbsKey];
+
+        Assert.IsTrue(id < BrightscriptScientificThreshold, "WCBS ID must stay below 1e7 for Roku.");
+        Assert.AreNotEqual(815011305, id, "Must not regress to the old 31-bit ID that broke Roku.");
+        Assert.AreEqual(wcbsKey, assignment.IdToKey[id], "WCBS ID must resolve back to WCBS.");
+    }
+
+    // ---- Backward-compatibility bridge: cached clients keep working without a re-pull ----------
+
+    [TestMethod]
+    public void LegacyBridge_OldHighIds_StillResolveToTheirChannel_SoCachedClientsKeepWorking()
+    {
+        var keys = GenerateKeys(50_000);
+
+        var assignment = XtreamStreamIdCache.BuildAssignment(keys);
+
+        // Pick keys whose pre-cap (31-bit) ID is above the cap — exactly the IDs NextPVR/Smarters
+        // still request from their cached lists.
+        var bridged = keys
+            .Where(k => XtreamStreamIdCache.ToLegacyStreamId(k) > XtreamStreamIdCache.MaxStreamId)
+            .Take(500)
+            .ToList();
+
+        Assert.IsTrue(bridged.Count > 0, "Expected some keys with pre-cap legacy IDs.");
+        foreach (var key in bridged)
+        {
+            var legacyId = XtreamStreamIdCache.ToLegacyStreamId(key);
+            Assert.AreEqual(key, assignment.LegacyIdToKey[legacyId],
+                "A cached pre-cap ID must still resolve to its own channel.");
+        }
+    }
+
+    [TestMethod]
+    public void LegacyBridge_OnlyBridgesAboveTheCap_SoItCannotCollideWithCurrentIds()
+    {
+        var keys = GenerateKeys(50_000);
+
+        var assignment = XtreamStreamIdCache.BuildAssignment(keys);
+
+        // Every bridged legacy ID is above the cap, hence disjoint from current (<= cap) IDs.
+        foreach (var legacyId in assignment.LegacyIdToKey.Keys)
+            Assert.IsTrue(legacyId > XtreamStreamIdCache.MaxStreamId,
+                $"Legacy ID {legacyId} is within the current ID range and would be ambiguous.");
+    }
+
+    [TestMethod]
+    public void LegacyBridge_ResolvesTheExactWcbsIdThatBrokePlayback()
+    {
+        // 815011305 is the old 31-bit ID NextPVR cached for WCBS and kept requesting.
+        const string wcbsKey = "hu4q9YO4P3veelAx";
+
+        var assignment = XtreamStreamIdCache.BuildAssignment([wcbsKey]);
+
+        Assert.AreEqual(815011305, XtreamStreamIdCache.ToLegacyStreamId(wcbsKey));
+        Assert.AreEqual(wcbsKey, assignment.LegacyIdToKey[815011305],
+            "The old WCBS ID must still resolve so cached clients recover without a re-pull.");
+    }
+}


### PR DESCRIPTION
Roku stream IDs capped at 23 bits in [XtreamStreamIdCache.cs](vscode-webview://04qr1c16coe2uakfnhv4ujd89nqki8vmtn7venn0rc5djlv1chd5/src/M3Undle.Web/Application/XtreamStreamIdCache.cs) so Brightscript renders them as plain integers (no scientific notation) — fixes both HLS and TS tuning.
stream_id/series_id returned as JSON strings in [XtreamEndpoints.cs](vscode-webview://04qr1c16coe2uakfnhv4ujd89nqki8vmtn7venn0rc5djlv1chd5/src/M3Undle.Web/Api/XtreamEndpoints.cs).
TS→HLS upgrade indicator: cyan "HLS" delivery chip in the stream monitor, driven by a proper UpgradedFromTs flag threaded through the generated-HLS session → client snapshot.
get_short_epg envelope fix and the burst-client .ts→HLS redirect (from earlier).

Fixes #122 