### PR TITLE
Core (src/M3Undle.Core/MpegTs/)

### DIFF
--- a/src/M3Undle.Core/MpegTs/MpegTsBoundaryScanner.cs
+++ b/src/M3Undle.Core/MpegTs/MpegTsBoundaryScanner.cs
@@ -15,6 +15,9 @@ public sealed class MpegTsBoundaryScanner
     private bool _pmtSeen;
     private bool _spsSeen;
     private bool _ppsSeen;
+    private long? _currentVideoPesDts90k;
+    private long? _batchLatestVideoDts90k;
+    private long? _batchIdrDts90k;
 
     public MpegTsPacketBatch? Process(ReadOnlySpan<byte> input)
     {
@@ -23,6 +26,8 @@ public sealed class MpegTsBoundaryScanner
 
         var dropped = 0;
         var syncLost = false;
+        _batchLatestVideoDts90k = null;
+        _batchIdrDts90k = null;
         _pending.AddRange(input);
 
         var output = new List<byte>(_pending.Count - (_pending.Count % PacketSize));
@@ -73,7 +78,14 @@ public sealed class MpegTsBoundaryScanner
         if (startupKind == MpegTsStartupKind.None)
             startupKind = MpegTsStartupKind.PacketBoundary;
 
-        return new MpegTsPacketBatch([.. output], startupKind, dropped, syncLost, _videoPid is not null);
+        return new MpegTsPacketBatch(
+            [.. output],
+            startupKind,
+            dropped,
+            syncLost,
+            _videoPid is not null,
+            _batchLatestVideoDts90k,
+            _batchIdrDts90k);
     }
 
     public void Reset()
@@ -86,6 +98,9 @@ public sealed class MpegTsBoundaryScanner
         _pmtSeen = false;
         _spsSeen = false;
         _ppsSeen = false;
+        _currentVideoPesDts90k = null;
+        _batchLatestVideoDts90k = null;
+        _batchIdrDts90k = null;
     }
 
     private bool LooksLikePacketStart(int index)
@@ -220,6 +235,10 @@ public sealed class MpegTsBoundaryScanner
     {
         if (payloadUnitStart && payload.Length >= 9 && payload[0] == 0 && payload[1] == 0 && payload[2] == 1)
         {
+            _currentVideoPesDts90k = ParsePesTimestamp(payload);
+            if (_currentVideoPesDts90k is { } dts)
+                _batchLatestVideoDts90k = dts;
+
             var pesHeaderLength = payload[8];
             var offset = 9 + pesHeaderLength;
             payload = offset <= payload.Length ? payload[offset..] : [];
@@ -227,8 +246,66 @@ public sealed class MpegTsBoundaryScanner
 
         AppendVideoPayload(payload);
         var parsedIdr = ScanH264NalUnits(CollectionsMarshal.AsSpan(_videoTail));
-        TrimVideoTail();
+        if (parsedIdr)
+        {
+            if (_currentVideoPesDts90k is { } idrDts)
+                _batchIdrDts90k = idrDts;
+
+            // The IDR signal has been consumed; clear the tail so packets that merely
+            // still contain these bytes do not re-report a stale IDR boundary.
+            _videoTail.Clear();
+        }
+        else
+        {
+            TrimVideoTail();
+        }
+
         return parsedIdr;
+    }
+
+    /// <summary>
+    /// Extracts the PES DTS (or PTS when no DTS is present) from a PES header at a
+    /// payload unit start, as a 33-bit 90 kHz value. Returns null for malformed or
+    /// timestamp-less headers rather than guessing.
+    /// </summary>
+    private static long? ParsePesTimestamp(ReadOnlySpan<byte> payload)
+    {
+        if (payload.Length < 14)
+            return null;
+
+        var streamId = payload[3];
+        if (streamId < 0xE0 || streamId > 0xEF)
+            return null;
+
+        var ptsDtsFlags = (payload[7] >> 6) & 0x03;
+        var pesHeaderDataLength = payload[8];
+        if (ptsDtsFlags == 0x02)
+        {
+            return pesHeaderDataLength >= 5
+                ? DecodeTimestamp(payload[9..14])
+                : null;
+        }
+
+        if (ptsDtsFlags == 0x03)
+        {
+            return pesHeaderDataLength >= 10 && payload.Length >= 19
+                ? DecodeTimestamp(payload[14..19])
+                : null;
+        }
+
+        return null;
+    }
+
+    private static long? DecodeTimestamp(ReadOnlySpan<byte> bytes)
+    {
+        if ((bytes[0] & 0x01) != 0x01 || (bytes[2] & 0x01) != 0x01 || (bytes[4] & 0x01) != 0x01)
+            return null;
+
+        return ((long)((bytes[0] >> 1) & 0x07) << 30)
+            | ((long)bytes[1] << 22)
+            | ((long)(bytes[2] >> 1) << 15)
+            | ((long)bytes[3] << 7)
+            | ((long)(bytes[4] >> 1));
     }
 
     private void AppendVideoPayload(ReadOnlySpan<byte> payload)

--- a/src/M3Undle.Core/MpegTs/MpegTsPacketBatch.cs
+++ b/src/M3Undle.Core/MpegTs/MpegTsPacketBatch.cs
@@ -5,4 +5,6 @@ public sealed record MpegTsPacketBatch(
     MpegTsStartupKind StartupKind,
     int DroppedByteCount,
     bool SyncLost,
-    bool HasKnownH264VideoStream = false);
+    bool HasKnownH264VideoStream = false,
+    long? LatestVideoDts90k = null,
+    long? IdrDts90k = null);

--- a/src/M3Undle.Core/MpegTs/MpegTsTimestamp.cs
+++ b/src/M3Undle.Core/MpegTs/MpegTsTimestamp.cs
@@ -1,0 +1,19 @@
+namespace M3Undle.Core.MpegTs;
+
+public static class MpegTsTimestamp
+{
+    public const long Wrap = 1L << 33;
+
+    public const double TicksPerSecond = 90000.0;
+
+    /// <summary>
+    /// Signed shortest distance from <paramref name="from"/> to <paramref name="to"/> on the
+    /// 33-bit PES timestamp circle, in 90 kHz ticks. Result is in [-Wrap/2, Wrap/2), so a
+    /// timestamp that wrapped mid-comparison still resolves to the small signed delta.
+    /// </summary>
+    public static long Delta(long from, long to)
+        => ((to - from + Wrap + Wrap / 2) % Wrap) - Wrap / 2;
+
+    public static double DeltaSeconds(long from, long to)
+        => Delta(from, to) / TicksPerSecond;
+}

--- a/src/M3Undle.Web/Streaming/Configuration/ReconnectOptions.cs
+++ b/src/M3Undle.Web/Streaming/Configuration/ReconnectOptions.cs
@@ -47,5 +47,29 @@ public sealed class ReconnectOptions
 
     public bool AllowPacketBoundaryRecoveryFallback { get; set; } = true;
 
+    /// <summary>
+    /// When a reconnected upstream replays content from before the failure point
+    /// (providers commonly serve ~60-70 s of ring buffer on a fresh connection),
+    /// keep holding output through the replayed span and resume at the first IDR
+    /// at/after the last video DTS relayed before the failure. The replay then
+    /// backfills the outage instead of flooding downstream with stale content.
+    /// </summary>
+    public bool EnableRecoveryOverlapTrim { get; set; } = true;
+
+    /// <summary>
+    /// Wall-clock budget for an active overlap trim. Rewind bursts arrive far faster
+    /// than real time; a provider replaying at 1x would never catch up, so on expiry
+    /// the trim is abandoned and recovery falls back to the standard first-IDR resume.
+    /// </summary>
+    public TimeSpan RecoveryOverlapTrimHoldLimit { get; set; } = TimeSpan.FromSeconds(6);
+
+    public int RecoveryOverlapTrimMaxBytes { get; set; } = 64 * 1024 * 1024;
+
+    /// <summary>
+    /// Rewinds larger than this are treated as an unrelated timestamp timeline
+    /// (e.g. the provider restarted its encoder) rather than a replay to trim.
+    /// </summary>
+    public int RecoveryOverlapTrimMaxRewindSeconds { get; set; } = 180;
+
     public int[] FixedStepBackoffSeconds { get; set; } = [0, 1, 2, 5, 10, 15, 30];
 }

--- a/src/M3Undle.Web/Streaming/Configuration/StreamingOptionsValidator.cs
+++ b/src/M3Undle.Web/Streaming/Configuration/StreamingOptionsValidator.cs
@@ -92,7 +92,7 @@ public sealed class ReconnectOptionsValidator : IValidateOptions<ReconnectOption
         if (options.RecoverySafeStartSearchLimitBytes < 188)
             errors.Add("Streaming:Reconnect:RecoverySafeStartSearchLimitBytes must be greater than or equal to one MPEG-TS packet.");
 
-        if (options.RecoveryOverlapTrimHoldLimit <= TimeSpan.Zero || options.RecoveryOverlapTrimHoldLimit > TimeSpan.FromSeconds(30))
+        if (options.RecoveryOverlapTrimHoldLimit < TimeSpan.FromMilliseconds(1) || options.RecoveryOverlapTrimHoldLimit > TimeSpan.FromSeconds(30))
             errors.Add("Streaming:Reconnect:RecoveryOverlapTrimHoldLimit must be between 1 millisecond and 30 seconds.");
 
         if (options.RecoveryOverlapTrimMaxBytes < 1024 * 1024)

--- a/src/M3Undle.Web/Streaming/Configuration/StreamingOptionsValidator.cs
+++ b/src/M3Undle.Web/Streaming/Configuration/StreamingOptionsValidator.cs
@@ -92,6 +92,15 @@ public sealed class ReconnectOptionsValidator : IValidateOptions<ReconnectOption
         if (options.RecoverySafeStartSearchLimitBytes < 188)
             errors.Add("Streaming:Reconnect:RecoverySafeStartSearchLimitBytes must be greater than or equal to one MPEG-TS packet.");
 
+        if (options.RecoveryOverlapTrimHoldLimit <= TimeSpan.Zero || options.RecoveryOverlapTrimHoldLimit > TimeSpan.FromSeconds(30))
+            errors.Add("Streaming:Reconnect:RecoveryOverlapTrimHoldLimit must be between 1 millisecond and 30 seconds.");
+
+        if (options.RecoveryOverlapTrimMaxBytes < 1024 * 1024)
+            errors.Add("Streaming:Reconnect:RecoveryOverlapTrimMaxBytes must be at least 1 MiB.");
+
+        if (options.RecoveryOverlapTrimMaxRewindSeconds < 10 || options.RecoveryOverlapTrimMaxRewindSeconds > 600)
+            errors.Add("Streaming:Reconnect:RecoveryOverlapTrimMaxRewindSeconds must be between 10 and 600 seconds.");
+
         return errors.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(errors);

--- a/src/M3Undle.Web/Streaming/Observability/StreamDiagnosticEventKind.cs
+++ b/src/M3Undle.Web/Streaming/Observability/StreamDiagnosticEventKind.cs
@@ -31,4 +31,6 @@ public enum StreamDiagnosticEventKind
     ClientAbortAfterRecovery = 26,
     ControlledDownstreamRetune = 27,
     CleanWatchCompleted = 28,
+    RecoveryOverlapTrimmed = 29,
+    RecoveryOverlapTrimAbandoned = 30,
 }

--- a/src/M3Undle.Web/Streaming/Sessions/ChannelStreamSession.cs
+++ b/src/M3Undle.Web/Streaming/Sessions/ChannelStreamSession.cs
@@ -80,6 +80,13 @@ public sealed class ChannelStreamSession : IAsyncDisposable
     private string? _lastSafeStartKind;
     private double? _lastRecoveryOutputHeldMs;
     private DateTimeOffset? _lastRecoveryStartedUtc;
+    private long? _lastRelayedVideoDts90k;
+    private long? _recoveryTrimTargetDts90k;
+    private bool _recoveryTrimEvaluated;
+    private bool _recoveryTrimActive;
+    private long _recoveryTrimmedBytes;
+    private string _lastRecoveryTrimOutcome = RecoveryTrimOutcomes.NotApplicable;
+    private double? _lastRecoveryTrimRewindSeconds;
     private CancellationTokenSource? _idleCts;
     private string? _lastIdleGraceRemoteIp;
 
@@ -689,17 +696,20 @@ public sealed class ChannelStreamSession : IAsyncDisposable
             resetStallTimer = HasNonNullTsContent(batch.Data);
             Interlocked.Add(ref _mpegTsBytesSinceReset, batch.Data.Length);
             using var published = _buffer.Write(batch.Data);
+            var suppressForOverlapTrim = ShouldSuppressSafeStartForOverlapTrim(batch);
             var safeStart = MarkMpegTsSafeStartIfReady(
                 published,
                 batch.StartupKind,
                 batch.Data.Length,
-                batch.HasKnownH264VideoStream);
+                batch.HasKnownH264VideoStream,
+                suppressForOverlapTrim);
             if (_recoveryOutputHoldActive)
             {
                 _recoveryBytesSuppressed += batch.Data.Length;
                 if (safeStart.Selected)
                 {
                     await ResumeRecoveryOutputAsync(safeStart.Kind);
+                    UpdateLastRelayedVideoDts(batch);
                 }
                 else if (IsRecoveryHoldLimitExceeded())
                 {
@@ -710,6 +720,7 @@ public sealed class ChannelStreamSession : IAsyncDisposable
             }
 
             await PublishToSubscribersAsync(published, isAtSafeBoundary: safeStart.Selected);
+            UpdateLastRelayedVideoDts(batch);
         }
         else
         {
@@ -978,7 +989,8 @@ public sealed class ChannelStreamSession : IAsyncDisposable
         BufferLease lease,
         MpegTsStartupKind kind,
         int batchLength,
-        bool hasKnownH264VideoStream)
+        bool hasKnownH264VideoStream,
+        bool suppressSelection = false)
     {
         var fallbackBytes = ResolveRecoverySafeStartSearchLimitBytes();
 
@@ -989,6 +1001,12 @@ public sealed class ChannelStreamSession : IAsyncDisposable
                 ? Math.Max(0, lease.Sequence - 1)
                 : lease.Sequence;
         }
+
+        // An active overlap trim keeps holding through replayed pre-failure content;
+        // the PAT/PMT candidate above must keep rolling forward, but neither an IDR
+        // from the replayed span nor the byte-count fallback may resume output.
+        if (suppressSelection)
+            return SafeStartDecision.NotSelected;
 
         var selected = kind == MpegTsStartupKind.H264Idr
             || (kind == MpegTsStartupKind.PatPmt && !hasKnownH264VideoStream);
@@ -1032,6 +1050,16 @@ public sealed class ChannelStreamSession : IAsyncDisposable
         _recoveryOutputHoldStartedUtc = DateTimeOffset.UtcNow;
         _lastRecoveryStartedUtc = _recoveryOutputHoldStartedUtc;
         _recoveryBytesSuppressed = 0;
+        _recoveryTrimTargetDts90k = _reconnectOptions.EnableRecoveryOverlapTrim
+            ? _lastRelayedVideoDts90k
+            : null;
+        _recoveryTrimEvaluated = false;
+        _recoveryTrimActive = false;
+        _recoveryTrimmedBytes = 0;
+        _lastRecoveryTrimOutcome = _recoveryTrimTargetDts90k is null
+            ? RecoveryTrimOutcomes.NotApplicable
+            : RecoveryTrimOutcomes.None;
+        _lastRecoveryTrimRewindSeconds = null;
         _currentRecoveryPolicy ??= StreamChannelRecoveryPolicy.FromOptions(_reconnectOptions);
         var policy = ResolveRecoveryPolicy();
         SetState(SessionState.HoldingOutput);
@@ -1114,7 +1142,7 @@ public sealed class ChannelStreamSession : IAsyncDisposable
             recoveryHoldLimit: ResolveRecoveryPolicy().RecoveryOutputHoldLimit,
             message: "Downstream output resumed from recovered MPEG-TS safe start.");
         _logger.LogInformation(
-            "Recovery resumed: SessionId={SessionId} DisplayName={DisplayName} ProviderId={ProviderId} ProviderChannelId={ProviderChannelId} RelayMode={RelayMode} SafeStartKind={SafeStartKind} OutputHeldMs={OutputHeldMs} BytesSuppressed={BytesSuppressed}",
+            "Recovery resumed: SessionId={SessionId} DisplayName={DisplayName} ProviderId={ProviderId} ProviderChannelId={ProviderChannelId} RelayMode={RelayMode} SafeStartKind={SafeStartKind} OutputHeldMs={OutputHeldMs} BytesSuppressed={BytesSuppressed} TrimOutcome={TrimOutcome} TrimRewindSeconds={TrimRewindSeconds} TrimmedBytes={TrimmedBytes}",
             _sessionId,
             _source.DisplayName,
             _source.ProviderId,
@@ -1122,7 +1150,10 @@ public sealed class ChannelStreamSession : IAsyncDisposable
             _relayMode,
             safeStartKind,
             heldDuration.TotalMilliseconds,
-            _recoveryBytesSuppressed);
+            _recoveryBytesSuppressed,
+            _lastRecoveryTrimOutcome,
+            _lastRecoveryTrimRewindSeconds,
+            _recoveryTrimmedBytes);
         PublishSnapshots();
     }
 
@@ -1182,6 +1213,12 @@ public sealed class ChannelStreamSession : IAsyncDisposable
         if (!_recoveryOutputHoldActive)
             return false;
 
+        // An active overlap trim intentionally suppresses far more than the standard
+        // safe-start budgets allow; it enforces its own limits and abandoning it resets
+        // the standard budgets, so the forced-retune path must not fire here.
+        if (_recoveryTrimActive)
+            return false;
+
         return GetRecoveryHoldDuration() >= ResolveRecoveryPolicy().RecoveryOutputHoldLimit
             || _recoveryBytesSuppressed >= ResolveRecoverySafeStartSearchLimitBytes();
     }
@@ -1190,6 +1227,115 @@ public sealed class ChannelStreamSession : IAsyncDisposable
         => _recoveryOutputHoldStartedUtc is { } started
             ? DateTimeOffset.UtcNow - started
             : TimeSpan.Zero;
+
+    private void UpdateLastRelayedVideoDts(MpegTsPacketBatch batch)
+    {
+        if (batch.LatestVideoDts90k is { } dts)
+            _lastRelayedVideoDts90k = dts;
+    }
+
+    private bool ShouldSuppressSafeStartForOverlapTrim(MpegTsPacketBatch batch)
+    {
+        if (!_recoveryOutputHoldActive || _recoveryTrimTargetDts90k is not { } target)
+            return false;
+
+        if (!_recoveryTrimEvaluated)
+        {
+            if (!batch.HasKnownH264VideoStream || batch.LatestVideoDts90k is not { } firstDts)
+                return false;
+
+            _recoveryTrimEvaluated = true;
+            var deltaSeconds = MpegTsTimestamp.DeltaSeconds(target, firstDts);
+            if (deltaSeconds >= 0)
+            {
+                _lastRecoveryTrimOutcome = RecoveryTrimOutcomes.None;
+                return false;
+            }
+
+            if (deltaSeconds < -_reconnectOptions.RecoveryOverlapTrimMaxRewindSeconds)
+            {
+                _lastRecoveryTrimOutcome = RecoveryTrimOutcomes.NotApplicable;
+                _logger.LogInformation(
+                    "Recovery overlap trim skipped: SessionId={SessionId} DisplayName={DisplayName} reconnected stream is {RewindSeconds:F1}s behind the pre-failure position, beyond the {MaxRewindSeconds}s trim window; treating as an unrelated timeline.",
+                    _sessionId,
+                    _source.DisplayName,
+                    -deltaSeconds,
+                    _reconnectOptions.RecoveryOverlapTrimMaxRewindSeconds);
+                return false;
+            }
+
+            _recoveryTrimActive = true;
+            _lastRecoveryTrimRewindSeconds = -deltaSeconds;
+            _logger.LogInformation(
+                "Recovery overlap detected: SessionId={SessionId} DisplayName={DisplayName} reconnected stream is {RewindSeconds:F1}s behind the pre-failure position; holding output through the replayed span.",
+                _sessionId,
+                _source.DisplayName,
+                -deltaSeconds);
+        }
+
+        if (!_recoveryTrimActive)
+            return false;
+
+        if (GetRecoveryHoldDuration() >= _reconnectOptions.RecoveryOverlapTrimHoldLimit
+            || _recoveryTrimmedBytes >= _reconnectOptions.RecoveryOverlapTrimMaxBytes)
+        {
+            AbandonRecoveryOverlapTrim();
+            return false;
+        }
+
+        if (batch.IdrDts90k is { } idrDts && MpegTsTimestamp.Delta(target, idrDts) >= 0)
+        {
+            CompleteRecoveryOverlapTrim(target, idrDts);
+            return false;
+        }
+
+        _recoveryTrimmedBytes += batch.Data.Length;
+        return true;
+    }
+
+    private void CompleteRecoveryOverlapTrim(long targetDts90k, long resumeIdrDts90k)
+    {
+        _recoveryTrimActive = false;
+        _lastRecoveryTrimOutcome = RecoveryTrimOutcomes.Trimmed;
+        var overshootSeconds = MpegTsTimestamp.DeltaSeconds(targetDts90k, resumeIdrDts90k);
+        RecordDiagnostic(
+            StreamDiagnosticEventKind.RecoveryOverlapTrimmed,
+            outputHeld: GetRecoveryHoldDuration(),
+            bytesSuppressed: _recoveryTrimmedBytes,
+            message: $"Recovery overlap trimmed: {_lastRecoveryTrimRewindSeconds:F1}s of replayed content ({_recoveryTrimmedBytes} byte(s)) suppressed; resuming at IDR {overshootSeconds:F1}s past the pre-failure position.");
+        _logger.LogInformation(
+            "Recovery overlap trimmed: SessionId={SessionId} DisplayName={DisplayName} RewindSeconds={RewindSeconds:F1} TrimmedBytes={TrimmedBytes} ResumeOvershootSeconds={ResumeOvershootSeconds:F1}",
+            _sessionId,
+            _source.DisplayName,
+            _lastRecoveryTrimRewindSeconds,
+            _recoveryTrimmedBytes,
+            overshootSeconds);
+    }
+
+    private void AbandonRecoveryOverlapTrim()
+    {
+        _recoveryTrimActive = false;
+        _lastRecoveryTrimOutcome = RecoveryTrimOutcomes.Abandoned;
+        var heldDuration = GetRecoveryHoldDuration();
+        RecordDiagnostic(
+            StreamDiagnosticEventKind.RecoveryOverlapTrimAbandoned,
+            outputHeld: heldDuration,
+            bytesSuppressed: _recoveryTrimmedBytes,
+            message: $"Recovery overlap trim abandoned after {heldDuration.TotalMilliseconds:F0} ms / {_recoveryTrimmedBytes} byte(s) without reaching the pre-failure position; falling back to the standard safe-start resume.");
+        _logger.LogWarning(
+            "Recovery overlap trim abandoned: SessionId={SessionId} DisplayName={DisplayName} RewindSeconds={RewindSeconds:F1} TrimmedBytes={TrimmedBytes} HeldMs={HeldMs:F0}",
+            _sessionId,
+            _source.DisplayName,
+            _lastRecoveryTrimRewindSeconds,
+            _recoveryTrimmedBytes,
+            heldDuration.TotalMilliseconds);
+
+        // Restart the standard hold budgets so the fallback resume gets its normal
+        // window instead of tripping the forced-retune limits the trim already spent.
+        _recoveryOutputHoldStartedUtc = DateTimeOffset.UtcNow;
+        _recoveryBytesSuppressed = 0;
+        Interlocked.Exchange(ref _mpegTsBytesSinceReset, 0);
+    }
 
     private int ResolveRecoverySafeStartSearchLimitBytes()
     {
@@ -1816,5 +1962,13 @@ public sealed class ChannelStreamSession : IAsyncDisposable
     private readonly record struct SafeStartDecision(bool Selected, string Kind)
     {
         public static SafeStartDecision NotSelected => new(false, string.Empty);
+    }
+
+    private static class RecoveryTrimOutcomes
+    {
+        public const string NotApplicable = "NotApplicable";
+        public const string None = "None";
+        public const string Trimmed = "Trimmed";
+        public const string Abandoned = "Abandoned";
     }
 }

--- a/src/M3Undle.Web/appsettings.json
+++ b/src/M3Undle.Web/appsettings.json
@@ -108,6 +108,10 @@
         "RecoveryOutputHoldLimit": "00:00:03",
         "RecoverySafeStartSearchLimitBytes": 2097152,
         "AllowPacketBoundaryRecoveryFallback": true,
+        "EnableRecoveryOverlapTrim": true,
+        "RecoveryOverlapTrimHoldLimit": "00:00:06",
+        "RecoveryOverlapTrimMaxBytes": 67108864,
+        "RecoveryOverlapTrimMaxRewindSeconds": 180,
         "FixedStepBackoffSeconds": [ 0, 1, 2, 5, 10, 15, 30 ]
       },
       "GeneratedHls": {

--- a/tests/M3Undle.Core.Tests/MpegTs/MpegTsBoundaryScannerTests.cs
+++ b/tests/M3Undle.Core.Tests/MpegTs/MpegTsBoundaryScannerTests.cs
@@ -173,6 +173,121 @@ public sealed class MpegTsBoundaryScannerTests
         Assert.AreEqual(MpegTsStartupKind.PatPmt, batch.StartupKind);
     }
 
+    [TestMethod]
+    public void Process_VideoPesWithPtsAndDts_ReportsDts()
+    {
+        var scanner = new MpegTsBoundaryScanner();
+        const long pts = 5_400_000;
+        const long dts = 5_396_400;
+        var input = PatPacket(100)
+            .Concat(PmtPacket(100, 256))
+            .Concat(VideoPacketWithTimestamps(256, [0x00, 0x00, 0x01, 0x41, 0x01], pts, dts))
+            .ToArray();
+
+        var batch = scanner.Process(input);
+
+        Assert.IsNotNull(batch);
+        Assert.AreEqual(dts, batch.LatestVideoDts90k);
+        Assert.IsNull(batch.IdrDts90k);
+    }
+
+    [TestMethod]
+    public void Process_VideoPesWithPtsOnly_ReportsPtsAsDts()
+    {
+        var scanner = new MpegTsBoundaryScanner();
+        const long pts = 7_200_000;
+        var input = PatPacket(100)
+            .Concat(PmtPacket(100, 256))
+            .Concat(VideoPacketWithTimestamps(256, [0x00, 0x00, 0x01, 0x41, 0x01], pts, dts: null))
+            .ToArray();
+
+        var batch = scanner.Process(input);
+
+        Assert.IsNotNull(batch);
+        Assert.AreEqual(pts, batch.LatestVideoDts90k);
+    }
+
+    [TestMethod]
+    public void Process_VideoPesWithoutParseableTimestamp_StillDetectsIdrWithNullDts()
+    {
+        // The plain VideoPacket helper writes a PES header that claims PTS presence but
+        // has a zero header-data length; the parser must return null rather than guess.
+        var scanner = new MpegTsBoundaryScanner();
+        var input = PatPacket(100)
+            .Concat(PmtPacket(100, 256))
+            .Concat(VideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0x01, 0x02]))
+            .Concat(VideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0x03, 0x04]))
+            .Concat(VideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0x05, 0x06]))
+            .ToArray();
+
+        var batch = scanner.Process(input);
+
+        Assert.IsNotNull(batch);
+        Assert.AreEqual(MpegTsStartupKind.H264Idr, batch.StartupKind);
+        Assert.IsNull(batch.LatestVideoDts90k);
+        Assert.IsNull(batch.IdrDts90k);
+    }
+
+    [TestMethod]
+    public void Process_IdrWithTimestamp_ReportsIdrDts()
+    {
+        var scanner = new MpegTsBoundaryScanner();
+        const long idrDts = 9_000_000;
+        var input = PatPacket(100)
+            .Concat(PmtPacket(100, 256))
+            .Concat(VideoPacketWithTimestamps(256, [0x00, 0x00, 0x01, 0x67, 0x01], idrDts - 7200, idrDts - 7200))
+            .Concat(VideoPacketWithTimestamps(256, [0x00, 0x00, 0x01, 0x68, 0x02], idrDts - 3600, idrDts - 3600))
+            .Concat(VideoPacketWithTimestamps(256, [0x00, 0x00, 0x01, 0x65, 0x03], idrDts, idrDts))
+            .ToArray();
+
+        var batch = scanner.Process(input);
+
+        Assert.IsNotNull(batch);
+        Assert.AreEqual(MpegTsStartupKind.H264Idr, batch.StartupKind);
+        Assert.AreEqual(idrDts, batch.IdrDts90k);
+        Assert.AreEqual(idrDts, batch.LatestVideoDts90k);
+    }
+
+    [TestMethod]
+    public void Process_PacketAfterIdr_DoesNotReReportStaleIdr()
+    {
+        var scanner = new MpegTsBoundaryScanner();
+        const long idrDts = 9_000_000;
+        var idrSequence = PatPacket(100)
+            .Concat(PmtPacket(100, 256))
+            .Concat(VideoPacketWithTimestamps(256, [0x00, 0x00, 0x01, 0x67, 0x01], idrDts, idrDts))
+            .Concat(VideoPacketWithTimestamps(256, [0x00, 0x00, 0x01, 0x68, 0x02], idrDts, idrDts))
+            .Concat(VideoPacketWithTimestamps(256, [0x00, 0x00, 0x01, 0x65, 0x03], idrDts, idrDts))
+            .ToArray();
+
+        var idrBatch = scanner.Process(idrSequence);
+        Assert.AreEqual(MpegTsStartupKind.H264Idr, idrBatch?.StartupKind);
+
+        // A continuation packet with no start codes must not re-report the consumed IDR.
+        var followUp = scanner.Process(Packet(256));
+
+        Assert.IsNotNull(followUp);
+        Assert.AreEqual(MpegTsStartupKind.PacketBoundary, followUp.StartupKind);
+        Assert.IsNull(followUp.IdrDts90k);
+    }
+
+    [TestMethod]
+    public void Reset_ClearsTimestampState()
+    {
+        var scanner = new MpegTsBoundaryScanner();
+        var input = PatPacket(100)
+            .Concat(PmtPacket(100, 256))
+            .Concat(VideoPacketWithTimestamps(256, [0x00, 0x00, 0x01, 0x41, 0x01], 90000, 90000))
+            .ToArray();
+        Assert.AreEqual(90000, scanner.Process(input)?.LatestVideoDts90k);
+
+        scanner.Reset();
+
+        var afterReset = scanner.Process(PatPacket(100));
+        Assert.IsNull(afterReset?.LatestVideoDts90k);
+        Assert.IsNull(afterReset?.IdrDts90k);
+    }
+
     private static byte[] PatPacket(int pmtPid)
         => Packet(0, payloadUnitStart: true,
         [
@@ -207,6 +322,33 @@ public sealed class MpegTsBoundaryScannerTests
     private static byte[] VideoPacket(int videoPid, byte[] annexB)
         => Packet(videoPid, payloadUnitStart: true,
             [0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x80, 0x80, 0x00, .. annexB]);
+
+    private static byte[] VideoPacketWithTimestamps(int videoPid, byte[] annexB, long pts, long? dts)
+    {
+        byte[] header = dts is { } dtsValue
+            ?
+            [
+                0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x80, 0xC0, 0x0A,
+                .. EncodePesTimestamp(0x03, pts),
+                .. EncodePesTimestamp(0x01, dtsValue),
+            ]
+            :
+            [
+                0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x80, 0x80, 0x05,
+                .. EncodePesTimestamp(0x02, pts),
+            ];
+        return Packet(videoPid, payloadUnitStart: true, [.. header, .. annexB]);
+    }
+
+    private static byte[] EncodePesTimestamp(int prefix, long value)
+        =>
+        [
+            (byte)((prefix << 4) | (int)(((value >> 30) & 0x07) << 1) | 0x01),
+            (byte)((value >> 22) & 0xFF),
+            (byte)((((value >> 15) & 0x7F) << 1) | 0x01),
+            (byte)((value >> 7) & 0xFF),
+            (byte)(((value & 0x7F) << 1) | 0x01),
+        ];
 
     private static byte[] AudioOnlyPmtPacket(int pmtPid)
         => Packet(pmtPid, payloadUnitStart: true,

--- a/tests/M3Undle.Core.Tests/MpegTs/MpegTsTimestampTests.cs
+++ b/tests/M3Undle.Core.Tests/MpegTs/MpegTsTimestampTests.cs
@@ -1,0 +1,55 @@
+using M3Undle.Core.MpegTs;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace M3Undle.Core.Tests.MpegTs;
+
+[TestClass]
+public sealed class MpegTsTimestampTests
+{
+    [TestMethod]
+    public void Delta_ForwardDistance_IsPositive()
+    {
+        Assert.AreEqual(90000, MpegTsTimestamp.Delta(0, 90000));
+        Assert.AreEqual(1.0, MpegTsTimestamp.DeltaSeconds(0, 90000));
+    }
+
+    [TestMethod]
+    public void Delta_BackwardDistance_IsNegative()
+    {
+        Assert.AreEqual(-90000, MpegTsTimestamp.Delta(90000, 0));
+        Assert.AreEqual(-1.0, MpegTsTimestamp.DeltaSeconds(90000, 0));
+    }
+
+    [TestMethod]
+    public void Delta_SamePosition_IsZero()
+        => Assert.AreEqual(0, MpegTsTimestamp.Delta(123456789, 123456789));
+
+    [TestMethod]
+    public void Delta_ForwardAcrossWrap_IsSmallPositive()
+    {
+        // 1 s before the wrap point → 1 s after it: forward 2 s, not backward ~26.5 h.
+        var before = MpegTsTimestamp.Wrap - 90000;
+        Assert.AreEqual(180000, MpegTsTimestamp.Delta(before, 90000));
+    }
+
+    [TestMethod]
+    public void Delta_BackwardAcrossWrap_IsSmallNegative()
+    {
+        // 1 s after the wrap point → 1 s before it: backward 2 s.
+        var after = 90000L;
+        Assert.AreEqual(-180000, MpegTsTimestamp.Delta(after, MpegTsTimestamp.Wrap - 90000));
+    }
+
+    [TestMethod]
+    public void Delta_HalfCircle_IsNegativeBoundary()
+        => Assert.AreEqual(-MpegTsTimestamp.Wrap / 2, MpegTsTimestamp.Delta(0, MpegTsTimestamp.Wrap / 2));
+
+    [TestMethod]
+    public void Delta_TypicalProviderRewind_IsNegativeSixtySeconds()
+    {
+        // Live edge at t, reconnected stream serves from t-60 s.
+        var liveEdge = 3384789480L;
+        var rewound = liveEdge - 60 * 90000;
+        Assert.AreEqual(-60.0, MpegTsTimestamp.DeltaSeconds(liveEdge, rewound));
+    }
+}

--- a/tests/M3Undle.Web.Tests/Streaming/ChannelSessionIntegrationTests.cs
+++ b/tests/M3Undle.Web.Tests/Streaming/ChannelSessionIntegrationTests.cs
@@ -946,6 +946,360 @@ public sealed class ChannelSessionIntegrationTests
     }
 
     [TestMethod]
+    public async Task Session_MpegTsReconnect_RewoundReplay_TrimsToPreFailurePosition()
+    {
+        // Provider behavior observed on toontown-tv-srv1: a reconnected upstream fast-bursts
+        // ~60 s of content from before the failure point. The overlap trim must suppress the
+        // replayed span and resume at the first IDR at/after the last DTS relayed pre-failure.
+        const long preFailureDts = 102L * 90000;
+        var rewoundIdr = TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xA5], 42L * 90000);
+        var caughtUpIdr = TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xC5], 104L * 90000);
+
+        var preFailureSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0x91], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0x92], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0x93], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x41, 0x94], 101L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x41, 0x95], preFailureDts),
+        };
+
+        // Rewound burst: 14 packets (> the 8-packet safe-start search limit below) before the
+        // caught-up IDR — regression guard that an active trim bypasses the forced-retune limits.
+        var recoveredSequence = new List<byte[]>
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0xA1], 42L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0xA2], 42L * 90000),
+            rewoundIdr,
+        };
+        for (var i = 0; i < 6; i++)
+            recoveredSequence.Add(TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x41, (byte)(0xA6 + i)], (43 + i) * 90000L));
+        recoveredSequence.Add(TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xB5], 72L * 90000));
+        recoveredSequence.Add(PatPacket(100));
+        recoveredSequence.Add(PmtPacket(100, 256));
+        recoveredSequence.Add(caughtUpIdr);
+
+        var filler = FakeStreamingHandler.ValidTsPacket(0xCC);
+        var handler = FakeStreamingHandler.StreamForever(filler);
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenStall(preFailureSequence, ct));
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenForever(recoveredSequence, filler, ct));
+
+        await using var fixture = await SessionFixture.CreateAsync(
+            handler,
+            reconnectOptions: new ReconnectOptions
+            {
+                ReadStallTimeout = TimeSpan.FromMilliseconds(200),
+                RecoveryOutputHoldLimit = TimeSpan.FromSeconds(2),
+                RecoverySafeStartSearchLimitBytes = 8 * 188,
+                OutageWindow = TimeSpan.FromSeconds(30),
+                ConnectTimeout = TimeSpan.FromSeconds(5),
+                FixedStepBackoffSeconds = [0],
+            });
+
+        var session = await fixture.Manager.GetOrCreateAsync(fixture.Source, CancellationToken.None);
+        var capture = CreateResponseCaptureContext();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var subscriber = await session.AttachSubscriberAsync(capture.Context, cts.Token);
+
+        await WaitUntilAsync(
+            () => fixture.DiagnosticsStore.Query(
+                sessionId: session.SessionId,
+                kind: StreamDiagnosticEventKind.RecoveryOutputResumed).Count > 0,
+            TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(() => IndexOf(capture.Body.ToArray(), caughtUpIdr) >= 0, TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        await subscriber.CompleteAsync(SubscriberDisconnectReason.ClientAborted);
+        await subscriber.Completion.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var data = capture.Body.ToArray();
+        Assert.AreEqual(-1, IndexOf(data, rewoundIdr), "Replayed pre-failure content must be trimmed, not relayed.");
+        Assert.IsGreaterThanOrEqualTo(0, IndexOf(data, caughtUpIdr), "Output must resume at the caught-up IDR.");
+
+        Assert.IsNotEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimmed));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimAbandoned));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryFailedUnsafe));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryForcedRetune));
+
+        var trimmed = fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimmed).First();
+        Assert.IsGreaterThan(0, trimmed.BytesSuppressed.GetValueOrDefault());
+
+        await session.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task Session_MpegTsReconnect_SlowRewoundReplay_TrimAbandonedWithoutForcedRetune()
+    {
+        // A provider that replays rewound content at 1x would never catch up to the
+        // pre-failure DTS; the trim must give up at its hold limit and fall back to the
+        // standard first-IDR resume instead of forcing a retune.
+        const long preFailureDts = 102L * 90000;
+        var rewoundIdr = TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xD5], 43L * 90000);
+
+        var preFailureSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0x91], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0x92], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0x93], preFailureDts),
+        };
+
+        var recoveredOnce = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0xA1], 42L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0xA2], 42L * 90000),
+        };
+
+        var handler = FakeStreamingHandler.StreamForever(rewoundIdr);
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenStall(preFailureSequence, ct));
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenForever(recoveredOnce, rewoundIdr, ct));
+
+        await using var fixture = await SessionFixture.CreateAsync(
+            handler,
+            reconnectOptions: new ReconnectOptions
+            {
+                ReadStallTimeout = TimeSpan.FromMilliseconds(200),
+                RecoveryOutputHoldLimit = TimeSpan.FromSeconds(2),
+                RecoveryOverlapTrimHoldLimit = TimeSpan.FromMilliseconds(100),
+                OutageWindow = TimeSpan.FromSeconds(30),
+                ConnectTimeout = TimeSpan.FromSeconds(5),
+                FixedStepBackoffSeconds = [0],
+            });
+
+        var session = await fixture.Manager.GetOrCreateAsync(fixture.Source, CancellationToken.None);
+        var capture = CreateResponseCaptureContext();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var subscriber = await session.AttachSubscriberAsync(capture.Context, cts.Token);
+
+        await WaitUntilAsync(
+            () => fixture.DiagnosticsStore.Query(
+                sessionId: session.SessionId,
+                kind: StreamDiagnosticEventKind.RecoveryOutputResumed).Count > 0,
+            TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(() => IndexOf(capture.Body.ToArray(), rewoundIdr) >= 0, TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        await subscriber.CompleteAsync(SubscriberDisconnectReason.ClientAborted);
+        await subscriber.Completion.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.IsNotEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimAbandoned));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimmed));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryFailedUnsafe));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryForcedRetune));
+
+        await session.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task Session_MpegTsReconnect_ForwardJump_ResumesAtFirstIdrWithoutTrim()
+    {
+        // Reconnected stream continues ahead of the pre-failure position (no replay):
+        // the standard first-IDR resume applies and no trim events are recorded.
+        var forwardIdr = TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xE5], 107L * 90000);
+
+        var preFailureSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0x91], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0x92], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0x93], 102L * 90000),
+        };
+
+        var recoveredSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0xA1], 107L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0xA2], 107L * 90000),
+            forwardIdr,
+        };
+
+        var filler = FakeStreamingHandler.ValidTsPacket(0xCC);
+        var handler = FakeStreamingHandler.StreamForever(filler);
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenStall(preFailureSequence, ct));
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenForever(recoveredSequence, filler, ct));
+
+        await using var fixture = await SessionFixture.CreateAsync(
+            handler,
+            reconnectOptions: new ReconnectOptions
+            {
+                ReadStallTimeout = TimeSpan.FromMilliseconds(200),
+                RecoveryOutputHoldLimit = TimeSpan.FromSeconds(2),
+                OutageWindow = TimeSpan.FromSeconds(30),
+                ConnectTimeout = TimeSpan.FromSeconds(5),
+                FixedStepBackoffSeconds = [0],
+            });
+
+        var session = await fixture.Manager.GetOrCreateAsync(fixture.Source, CancellationToken.None);
+        var capture = CreateResponseCaptureContext();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var subscriber = await session.AttachSubscriberAsync(capture.Context, cts.Token);
+
+        await WaitUntilAsync(
+            () => fixture.DiagnosticsStore.Query(
+                sessionId: session.SessionId,
+                kind: StreamDiagnosticEventKind.RecoveryOutputResumed).Count > 0,
+            TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(() => IndexOf(capture.Body.ToArray(), forwardIdr) >= 0, TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        await subscriber.CompleteAsync(SubscriberDisconnectReason.ClientAborted);
+        await subscriber.Completion.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.IsGreaterThanOrEqualTo(0, IndexOf(capture.Body.ToArray(), forwardIdr));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimmed));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimAbandoned));
+
+        await session.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task Session_MpegTsReconnect_UnrelatedTimeline_ResumesAtFirstIdrWithoutTrim()
+    {
+        // A rewind beyond RecoveryOverlapTrimMaxRewindSeconds means the provider restarted
+        // its timestamp timeline; treat it like today's recovery (first-IDR resume).
+        const long preFailureDts = 1000L * 90000;
+        var unrelatedIdr = TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xF5], 90000);
+
+        var preFailureSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0x91], preFailureDts),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0x92], preFailureDts),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0x93], preFailureDts),
+        };
+
+        var recoveredSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0xA1], 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0xA2], 90000),
+            unrelatedIdr,
+        };
+
+        var filler = FakeStreamingHandler.ValidTsPacket(0xCC);
+        var handler = FakeStreamingHandler.StreamForever(filler);
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenStall(preFailureSequence, ct));
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenForever(recoveredSequence, filler, ct));
+
+        await using var fixture = await SessionFixture.CreateAsync(
+            handler,
+            reconnectOptions: new ReconnectOptions
+            {
+                ReadStallTimeout = TimeSpan.FromMilliseconds(200),
+                RecoveryOutputHoldLimit = TimeSpan.FromSeconds(2),
+                OutageWindow = TimeSpan.FromSeconds(30),
+                ConnectTimeout = TimeSpan.FromSeconds(5),
+                FixedStepBackoffSeconds = [0],
+            });
+
+        var session = await fixture.Manager.GetOrCreateAsync(fixture.Source, CancellationToken.None);
+        var capture = CreateResponseCaptureContext();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var subscriber = await session.AttachSubscriberAsync(capture.Context, cts.Token);
+
+        await WaitUntilAsync(
+            () => fixture.DiagnosticsStore.Query(
+                sessionId: session.SessionId,
+                kind: StreamDiagnosticEventKind.RecoveryOutputResumed).Count > 0,
+            TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(() => IndexOf(capture.Body.ToArray(), unrelatedIdr) >= 0, TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        await subscriber.CompleteAsync(SubscriberDisconnectReason.ClientAborted);
+        await subscriber.Completion.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.IsGreaterThanOrEqualTo(0, IndexOf(capture.Body.ToArray(), unrelatedIdr),
+            "An unrelated timeline must resume at the first IDR like today's recovery.");
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimmed));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimAbandoned));
+
+        await session.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task Session_MpegTsReconnect_AudioOnlyRecoveredStream_ResumesWithoutTrim()
+    {
+        // A recovered stream with no H.264 video cannot be DTS-compared; the PAT/PMT
+        // safe-start path applies untouched.
+        var preFailureSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0x91], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0x92], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0x93], 102L * 90000),
+        };
+
+        var recoveredSequence = new[]
+        {
+            PatPacket(100),
+            AudioOnlyPmtPacket(100),
+        };
+
+        var filler = FakeStreamingHandler.ValidTsPacket(0xCC);
+        var handler = FakeStreamingHandler.StreamForever(filler);
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenStall(preFailureSequence, ct));
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenForever(recoveredSequence, filler, ct));
+
+        await using var fixture = await SessionFixture.CreateAsync(
+            handler,
+            reconnectOptions: new ReconnectOptions
+            {
+                ReadStallTimeout = TimeSpan.FromMilliseconds(200),
+                RecoveryOutputHoldLimit = TimeSpan.FromSeconds(2),
+                OutageWindow = TimeSpan.FromSeconds(30),
+                ConnectTimeout = TimeSpan.FromSeconds(5),
+                FixedStepBackoffSeconds = [0],
+            });
+
+        var session = await fixture.Manager.GetOrCreateAsync(fixture.Source, CancellationToken.None);
+        var capture = CreateResponseCaptureContext();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var subscriber = await session.AttachSubscriberAsync(capture.Context, cts.Token);
+
+        await WaitUntilAsync(
+            () => fixture.DiagnosticsStore.Query(
+                sessionId: session.SessionId,
+                kind: StreamDiagnosticEventKind.RecoveryOutputResumed).Count > 0,
+            TimeSpan.FromSeconds(10));
+
+        cts.Cancel();
+        await subscriber.CompleteAsync(SubscriberDisconnectReason.ClientAborted);
+        await subscriber.Completion.WaitAsync(TimeSpan.FromSeconds(2));
+
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimmed));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimAbandoned));
+
+        await session.DisposeAsync();
+    }
+
+    [TestMethod]
     public async Task Session_MpegTsReconnect_ZeroSubscribersAfterFirstSafeStart_SessionSurvivesAndEmitsSecondSafeStart()
     {
         // Reproduces the exact Bug 1 / TS-SAFE-02 trigger:
@@ -3020,6 +3374,25 @@ public sealed class ChannelSessionIntegrationTests
     private static byte[] VideoPacket(int videoPid, byte[] annexB)
         => Packet(videoPid, payloadUnitStart: true,
             [0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x80, 0x80, 0x00, .. annexB]);
+
+    private static byte[] TimestampedVideoPacket(int videoPid, byte[] annexB, long dts90k)
+        => Packet(videoPid, payloadUnitStart: true,
+        [
+            0x00, 0x00, 0x01, 0xE0, 0x00, 0x00, 0x80, 0xC0, 0x0A,
+            .. EncodePesTimestamp(0x03, dts90k),
+            .. EncodePesTimestamp(0x01, dts90k),
+            .. annexB,
+        ]);
+
+    private static byte[] EncodePesTimestamp(int prefix, long value)
+        =>
+        [
+            (byte)((prefix << 4) | (int)(((value >> 30) & 0x07) << 1) | 0x01),
+            (byte)((value >> 22) & 0xFF),
+            (byte)((((value >> 15) & 0x7F) << 1) | 0x01),
+            (byte)((value >> 7) & 0xFF),
+            (byte)(((value & 0x7F) << 1) | 0x01),
+        ];
 
     private static byte[] AudioOnlyPmtPacket(int pmtPid)
         => Packet(pmtPid, payloadUnitStart: true,


### PR DESCRIPTION
MpegTsTimestamp.cs — new wrap-aware 33-bit timestamp math (Delta/DeltaSeconds). MpegTsBoundaryScanner.cs — parses the video PES DTS (PTS when DTS absent, null on malformed headers) and reports LatestVideoDts90k plus IdrDts90k on each batch. Also fixes a latent issue found along the way: the H.264 tail is now cleared after a positive IDR detection, so packets that merely still contain old IDR bytes no longer re-report a stale safe boundary. Web (src/M3Undle.Web/)

ChannelStreamSession.cs — tracks the last relayed video DTS while live; on recovery, if the reconnected stream is 0–180s behind that mark, it keeps holding through the replay and resumes at the first IDR at/after the pre-failure position. The two forced-retune traps are gated: an active trim bypasses the hold/search limits, and the packet-boundary fallback can't fire mid-replay. Abandoning a trim (budget expiry) resets the standard budgets and falls back to today's first-IDR resume — never a retune. The "Recovery resumed" log now carries TrimOutcome, TrimRewindSeconds, and TrimmedBytes. ReconnectOptions.cs + appsettings.json + validator — EnableRecoveryOverlapTrim (on by default), 6s trim hold limit, 64MB byte budget, 180s max rewind. Two new diagnostic kinds: RecoveryOverlapTrimmed and RecoveryOverlapTrimAbandoned (diagnostics only — no DB schema change). Tests — 7 new Core tests (timestamp math incl. wraparound, DTS extraction, PTS-only, malformed-header guard, IDR-DTS association, stale-IDR regression) and 5 new integration scenarios (rewound replay trimmed with the search-limit regression guard folded in, slow 1× replay abandons without retune, forward jump unchanged, unrelated timeline unchanged, audio-only unchanged).

One deviation from the plan worth knowing: the Delta convention at the exact half-circle antipode came out [-Wrap/2, Wrap/2) instead of (-Wrap/2, Wrap/2] — irrelevant in practice (±13.25h deltas can't occur within the 180s trim window), so I aligned the doc and test to the formula.