### PR TITLE
Bug/trim failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to M3Undle are documented here. Newest release at the top.
 
 ---
 
+## [v1.0.0-beta.5] — 2026-07-12
+
+Beta 5 adds DTS-aware overlap trimming to provider reconnects, encryption key rotation, and VOD/series visibility on the stream monitor.
+
+### Adaptive recovery overlap trim
+
+- Added wrap-aware 33-bit MPEG-TS timestamp math and video PES DTS extraction to the boundary scanner, giving the recovery path a reliable measure of how far a reconnected stream has rewound
+- Added DTS-aware overlap trimming: when a provider reconnect replays 0–180s of already-delivered video (a common behavior on reconnect, e.g. AMC), M3Undle now holds through the replay and resumes at the first IDR at or after the pre-failure position instead of splicing the replayed IDR into the live HLS window and evicting viewer playback position
+- Gated the two existing forced-retune fallbacks so they can't fire while a trim is active or mid-replay; abandoning a trim on budget expiry falls back to the standard first-IDR resume, never a retune
+- Added `EnableRecoveryOverlapTrim` (on by default), plus configurable trim hold, byte budget, and max rewind limits under `ReconnectOptions`
+- Added `RecoveryOverlapTrimmed` and `RecoveryOverlapTrimAbandoned` diagnostic events, and extended the "Recovery resumed" log with trim outcome, rewind seconds, and trimmed byte count
+- Fixed a latent boundary-scanner issue where packets still containing old IDR bytes after a positive IDR detection could re-report a stale safe boundary
+
+### Encryption key rotation
+
+- Added the ability to rotate the secret encryption key used to protect stored Xtream and provider credentials, without requiring re-entry of existing secrets
+- Added a SQLite backup step ahead of rotation so a rotation can be safely rolled back
+- Documented the rotation workflow and previously undocumented Xtream fields in the Docker and database schema docs
+
+### VOD and series stream visibility
+
+- Added tracking of VOD and series streams against subscriber cap limits, alongside existing live-channel tracking
+- Fixed VOD and series streams not appearing on the stream monitor page (fixes #134)
+
+### Fixes
+
+- Fixed a validation message mismatch in `StreamingOptionsValidator`: the check allowed any value down to 1 tick through despite the message claiming a 1ms minimum; the check now matches the documented constraint
+
+### Testing
+
+- Added 7 new Core tests covering wrap-aware timestamp math, DTS extraction, PTS-only fallback, malformed-header handling, IDR/DTS association, and the stale-IDR regression
+- Added 5 new integration scenarios covering trimmed rewind replay, slow 1× replay abandonment, forward jumps, unrelated timelines, and audio-only streams
+- Added regression coverage for encryption rotation, secret encryption, and SQLite backup
+- Added regression coverage for VOD/series cap tracking and stream monitor visibility
+
+**Container images**
+
+```text
+ghcr.io/sydney-elvis/m3undle:v1.0.0-beta.5
+ghcr.io/sydney-elvis/m3undle:beta
+```
+
+---
+
 ## [v1.0.0-beta.4] — 2026-07-10
 
 Beta 4 is a focused adaptive stream health release. It removes false and dead signals from the channel health classifier that could push a channel to Unstable and force every viewer off on a benign disconnect, and it retires an eager forced-retune mechanism in favor of the existing evidence-based recovery path.

--- a/src/CoreVersion.props
+++ b/src/CoreVersion.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-beta.4</Version>
+    <Version>1.0.0-beta.5</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>

--- a/src/M3Undle.Web/Streaming/Configuration/ReconnectOptions.cs
+++ b/src/M3Undle.Web/Streaming/Configuration/ReconnectOptions.cs
@@ -71,5 +71,15 @@ public sealed class ReconnectOptions
     /// </summary>
     public int RecoveryOverlapTrimMaxRewindSeconds { get; set; } = 180;
 
+    /// <summary>
+    /// After a trim is abandoned, no new trim is armed for this long. A source that
+    /// fails faster than its replay can catch up (FFmpeg relay restarts produce a
+    /// rewound-looking timeline on every reconnect) would otherwise re-enter a fresh
+    /// trim with a fresh budget on every failure, suppressing output indefinitely;
+    /// the cooldown degrades such sources to the plain first-IDR resume instead.
+    /// Zero disables the cooldown.
+    /// </summary>
+    public TimeSpan RecoveryOverlapTrimRetryCooldown { get; set; } = TimeSpan.FromSeconds(60);
+
     public int[] FixedStepBackoffSeconds { get; set; } = [0, 1, 2, 5, 10, 15, 30];
 }

--- a/src/M3Undle.Web/Streaming/Configuration/StreamingOptionsValidator.cs
+++ b/src/M3Undle.Web/Streaming/Configuration/StreamingOptionsValidator.cs
@@ -101,6 +101,9 @@ public sealed class ReconnectOptionsValidator : IValidateOptions<ReconnectOption
         if (options.RecoveryOverlapTrimMaxRewindSeconds < 10 || options.RecoveryOverlapTrimMaxRewindSeconds > 600)
             errors.Add("Streaming:Reconnect:RecoveryOverlapTrimMaxRewindSeconds must be between 10 and 600 seconds.");
 
+        if (options.RecoveryOverlapTrimRetryCooldown < TimeSpan.Zero || options.RecoveryOverlapTrimRetryCooldown > TimeSpan.FromMinutes(30))
+            errors.Add("Streaming:Reconnect:RecoveryOverlapTrimRetryCooldown must be between 0 seconds and 30 minutes.");
+
         return errors.Count == 0
             ? ValidateOptionsResult.Success
             : ValidateOptionsResult.Fail(errors);

--- a/src/M3Undle.Web/Streaming/Sessions/ChannelStreamSession.cs
+++ b/src/M3Undle.Web/Streaming/Sessions/ChannelStreamSession.cs
@@ -87,6 +87,7 @@ public sealed class ChannelStreamSession : IAsyncDisposable
     private long _recoveryTrimmedBytes;
     private string _lastRecoveryTrimOutcome = RecoveryTrimOutcomes.NotApplicable;
     private double? _lastRecoveryTrimRewindSeconds;
+    private DateTimeOffset? _lastRecoveryTrimAbandonedUtc;
     private CancellationTokenSource? _idleCts;
     private string? _lastIdleGraceRemoteIp;
 
@@ -1046,13 +1047,32 @@ public sealed class ChannelStreamSession : IAsyncDisposable
 
     private void BeginRecoveryOutputHold(int reconnectAttempt)
     {
+        // A trim still active here means the upstream failed again before the replay
+        // reached the pre-failure position — the batch-driven trim budgets never got a
+        // chance to fire. Resolve it as abandoned so the outcome is recorded and the
+        // retry cooldown below stops a flapping source from re-entering a fresh trim
+        // (with a fresh budget) on every reconnect, which would suppress output forever.
+        if (_recoveryTrimActive)
+            AbandonRecoveryOverlapTrim("because the upstream failed again during the replayed span");
+
+        var holdStartedUtc = DateTimeOffset.UtcNow;
         _recoveryOutputHoldActive = true;
-        _recoveryOutputHoldStartedUtc = DateTimeOffset.UtcNow;
-        _lastRecoveryStartedUtc = _recoveryOutputHoldStartedUtc;
+        _recoveryOutputHoldStartedUtc = holdStartedUtc;
+        _lastRecoveryStartedUtc = holdStartedUtc;
         _recoveryBytesSuppressed = 0;
-        _recoveryTrimTargetDts90k = _reconnectOptions.EnableRecoveryOverlapTrim
+        var trimOnRetryCooldown = _lastRecoveryTrimAbandonedUtc is { } lastAbandonedUtc
+            && holdStartedUtc - lastAbandonedUtc < _reconnectOptions.RecoveryOverlapTrimRetryCooldown;
+        _recoveryTrimTargetDts90k = _reconnectOptions.EnableRecoveryOverlapTrim && !trimOnRetryCooldown
             ? _lastRelayedVideoDts90k
             : null;
+        if (trimOnRetryCooldown && _reconnectOptions.EnableRecoveryOverlapTrim && _lastRelayedVideoDts90k is not null)
+        {
+            _logger.LogInformation(
+                "Recovery overlap trim on retry cooldown: SessionId={SessionId} DisplayName={DisplayName} a trim was abandoned {SecondsSinceAbandoned:F1}s ago; using the standard safe-start resume for this recovery.",
+                _sessionId,
+                _source.DisplayName,
+                (holdStartedUtc - _lastRecoveryTrimAbandonedUtc!.Value).TotalSeconds);
+        }
         _recoveryTrimEvaluated = false;
         _recoveryTrimActive = false;
         _recoveryTrimmedBytes = 0;
@@ -1279,7 +1299,7 @@ public sealed class ChannelStreamSession : IAsyncDisposable
         if (GetRecoveryHoldDuration() >= _reconnectOptions.RecoveryOverlapTrimHoldLimit
             || _recoveryTrimmedBytes >= _reconnectOptions.RecoveryOverlapTrimMaxBytes)
         {
-            AbandonRecoveryOverlapTrim();
+            AbandonRecoveryOverlapTrim("without reaching the pre-failure position within the trim budget");
             return false;
         }
 
@@ -1312,23 +1332,25 @@ public sealed class ChannelStreamSession : IAsyncDisposable
             overshootSeconds);
     }
 
-    private void AbandonRecoveryOverlapTrim()
+    private void AbandonRecoveryOverlapTrim(string reason)
     {
         _recoveryTrimActive = false;
         _lastRecoveryTrimOutcome = RecoveryTrimOutcomes.Abandoned;
+        _lastRecoveryTrimAbandonedUtc = DateTimeOffset.UtcNow;
         var heldDuration = GetRecoveryHoldDuration();
         RecordDiagnostic(
             StreamDiagnosticEventKind.RecoveryOverlapTrimAbandoned,
             outputHeld: heldDuration,
             bytesSuppressed: _recoveryTrimmedBytes,
-            message: $"Recovery overlap trim abandoned after {heldDuration.TotalMilliseconds:F0} ms / {_recoveryTrimmedBytes} byte(s) without reaching the pre-failure position; falling back to the standard safe-start resume.");
+            message: $"Recovery overlap trim abandoned after {heldDuration.TotalMilliseconds:F0} ms / {_recoveryTrimmedBytes} byte(s) {reason}; falling back to the standard safe-start resume.");
         _logger.LogWarning(
-            "Recovery overlap trim abandoned: SessionId={SessionId} DisplayName={DisplayName} RewindSeconds={RewindSeconds:F1} TrimmedBytes={TrimmedBytes} HeldMs={HeldMs:F0}",
+            "Recovery overlap trim abandoned: SessionId={SessionId} DisplayName={DisplayName} RewindSeconds={RewindSeconds:F1} TrimmedBytes={TrimmedBytes} HeldMs={HeldMs:F0} Reason={Reason}",
             _sessionId,
             _source.DisplayName,
             _lastRecoveryTrimRewindSeconds,
             _recoveryTrimmedBytes,
-            heldDuration.TotalMilliseconds);
+            heldDuration.TotalMilliseconds,
+            reason);
 
         // Restart the standard hold budgets so the fallback resume gets its normal
         // window instead of tripping the forced-retune limits the trim already spent.

--- a/src/M3Undle.Web/appsettings.json
+++ b/src/M3Undle.Web/appsettings.json
@@ -112,6 +112,7 @@
         "RecoveryOverlapTrimHoldLimit": "00:00:06",
         "RecoveryOverlapTrimMaxBytes": 67108864,
         "RecoveryOverlapTrimMaxRewindSeconds": 180,
+        "RecoveryOverlapTrimRetryCooldown": "00:01:00",
         "FixedStepBackoffSeconds": [ 0, 1, 2, 5, 10, 15, 30 ]
       },
       "GeneratedHls": {

--- a/src/WebVersion.props
+++ b/src/WebVersion.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0-beta.4</Version>
+    <Version>1.0.0-beta.5</Version>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>

--- a/tests/M3Undle.Web.Tests/Streaming/ChannelSessionIntegrationTests.cs
+++ b/tests/M3Undle.Web.Tests/Streaming/ChannelSessionIntegrationTests.cs
@@ -1107,6 +1107,195 @@ public sealed class ChannelSessionIntegrationTests
     }
 
     [TestMethod]
+    public async Task Session_MpegTsReconnect_UpstreamFailsDuringTrim_AbandonsTrimAndResumesOnNextRecovery()
+    {
+        // Wedge shape observed on toontown-int-srv1 (CLEAN-RELAY-02 / XTR-WEB-01): the
+        // upstream fails again while a trim is still holding output, so the batch-driven
+        // trim budgets never fire. The failure path must resolve the trim as abandoned and
+        // the next recovery must resume plainly instead of re-entering a fresh trim.
+        const long preFailureDts = 102L * 90000;
+        var rewoundIdr = TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xE1], 43L * 90000);
+        var freshIdr = TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xE2], 200L * 90000);
+
+        var preFailureSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0x91], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0x92], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0x93], preFailureDts),
+        };
+
+        // Rewound replay that stalls before ever reaching the pre-failure position.
+        var rewoundThenStallSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0xA1], 42L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0xA2], 42L * 90000),
+            rewoundIdr,
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x41, 0xA3], 44L * 90000),
+        };
+
+        var secondRecoverySequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0xC1], 200L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0xC2], 200L * 90000),
+            freshIdr,
+        };
+
+        var filler = FakeStreamingHandler.ValidTsPacket(0xCC);
+        var handler = FakeStreamingHandler.StreamForever(filler);
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenStall(preFailureSequence, ct));
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenStall(rewoundThenStallSequence, ct));
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenForever(secondRecoverySequence, filler, ct));
+
+        await using var fixture = await SessionFixture.CreateAsync(
+            handler,
+            reconnectOptions: new ReconnectOptions
+            {
+                ReadStallTimeout = TimeSpan.FromMilliseconds(200),
+                RecoveryOutputHoldLimit = TimeSpan.FromSeconds(2),
+                OutageWindow = TimeSpan.FromSeconds(30),
+                ConnectTimeout = TimeSpan.FromSeconds(5),
+                FixedStepBackoffSeconds = [0],
+            });
+
+        var session = await fixture.Manager.GetOrCreateAsync(fixture.Source, CancellationToken.None);
+        var capture = CreateResponseCaptureContext();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var subscriber = await session.AttachSubscriberAsync(capture.Context, cts.Token);
+
+        await WaitUntilAsync(
+            () => fixture.DiagnosticsStore.Query(
+                sessionId: session.SessionId,
+                kind: StreamDiagnosticEventKind.RecoveryOutputResumed).Count > 0,
+            TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(() => IndexOf(capture.Body.ToArray(), freshIdr) >= 0, TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+        await subscriber.CompleteAsync(SubscriberDisconnectReason.ClientAborted);
+        await subscriber.Completion.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var data = capture.Body.ToArray();
+        Assert.AreEqual(-1, IndexOf(data, rewoundIdr), "Content suppressed by the wedged trim must not be relayed.");
+        Assert.IsGreaterThanOrEqualTo(0, IndexOf(data, freshIdr), "The recovery after the abandoned trim must resume output.");
+
+        Assert.IsNotEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimAbandoned));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimmed));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryFailedUnsafe));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryForcedRetune));
+
+        await session.DisposeAsync();
+    }
+
+    [TestMethod]
+    public async Task Session_MpegTsReconnect_FlappingSourceAfterAbandonedTrim_SkipsTrimDuringCooldown()
+    {
+        // After a trim is abandoned because the upstream failed mid-replay, a source that
+        // keeps flapping with a rewound-looking timeline (an FFmpeg relay restart produces
+        // one on every reconnect) must not re-arm the trim during the retry cooldown:
+        // recovery degrades to the plain first-IDR resume so output keeps flowing.
+        const long preFailureDts = 102L * 90000;
+        var rewoundIdr = TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xF1], 43L * 90000);
+        var freshIdr = TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xF2], 200L * 90000);
+        var secondRewoundIdr = TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0xF3], 150L * 90000);
+
+        var preFailureSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0x91], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0x92], 100L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x65, 0x93], preFailureDts),
+        };
+
+        var rewoundThenStallSequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0xA1], 42L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0xA2], 42L * 90000),
+            rewoundIdr,
+        };
+
+        var secondRecoverySequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0xC1], 200L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0xC2], 200L * 90000),
+            freshIdr,
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x41, 0xB1], 201L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x41, 0xB2], 202L * 90000),
+        };
+
+        // Third recovery rewinds again (50 s behind the fresh position) — within the trim
+        // window, but the cooldown from the abandoned trim must keep the trim disarmed.
+        var thirdRecoverySequence = new[]
+        {
+            PatPacket(100),
+            PmtPacket(100, 256),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x67, 0xC3], 150L * 90000),
+            TimestampedVideoPacket(256, [0x00, 0x00, 0x01, 0x68, 0xC4], 150L * 90000),
+            secondRewoundIdr,
+        };
+
+        var filler = FakeStreamingHandler.ValidTsPacket(0xCC);
+        var handler = FakeStreamingHandler.StreamForever(filler);
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenStall(preFailureSequence, ct));
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenStall(rewoundThenStallSequence, ct));
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenStall(secondRecoverySequence, ct));
+        handler.QueueNext(ct => FakeStreamingHandler.WriteSequenceThenForever(thirdRecoverySequence, filler, ct));
+
+        await using var fixture = await SessionFixture.CreateAsync(
+            handler,
+            reconnectOptions: new ReconnectOptions
+            {
+                ReadStallTimeout = TimeSpan.FromMilliseconds(200),
+                RecoveryOutputHoldLimit = TimeSpan.FromSeconds(2),
+                OutageWindow = TimeSpan.FromSeconds(30),
+                ConnectTimeout = TimeSpan.FromSeconds(5),
+                FixedStepBackoffSeconds = [0],
+            });
+
+        var session = await fixture.Manager.GetOrCreateAsync(fixture.Source, CancellationToken.None);
+        var capture = CreateResponseCaptureContext();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var subscriber = await session.AttachSubscriberAsync(capture.Context, cts.Token);
+
+        await WaitUntilAsync(() => IndexOf(capture.Body.ToArray(), secondRewoundIdr) >= 0, TimeSpan.FromSeconds(10));
+
+        cts.Cancel();
+        await subscriber.CompleteAsync(SubscriberDisconnectReason.ClientAborted);
+        await subscriber.Completion.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var data = capture.Body.ToArray();
+        Assert.IsGreaterThanOrEqualTo(0, IndexOf(data, freshIdr), "The recovery after the abandoned trim must resume output.");
+        Assert.IsGreaterThanOrEqualTo(
+            0,
+            IndexOf(data, secondRewoundIdr),
+            "A rewound recovery during the trim cooldown must resume plainly and relay its content.");
+
+        Assert.HasCount(1, fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimAbandoned));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryOverlapTrimmed));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryFailedUnsafe));
+        Assert.IsEmpty(fixture.DiagnosticsStore.Query(
+            sessionId: session.SessionId, kind: StreamDiagnosticEventKind.RecoveryForcedRetune));
+
+        await session.DisposeAsync();
+    }
+
+    [TestMethod]
     public async Task Session_MpegTsReconnect_ForwardJump_ResumesAtFirstIdrWithoutTrim()
     {
         // Reconnected stream continues ahead of the pre-failure position (no replay):


### PR DESCRIPTION
This branch fixes stream-recovery bugs found in beta.5 testing (adjusts ReconnectOptions/validator defaults and ChannelStreamSession trim logic, plus new integration test coverage), and re-applies the CHANGELOG/version bump to 1.0.0-beta.5 that had been accidentally dropped by an earlier revert.