### PR TITLE
The empty-state message in WhatsOnThisWeek.razor now uses the correct…

### DIFF
--- a/src/M3Undle.Web/Components/Pages/Channels/WhatsOnThisWeek.razor
+++ b/src/M3Undle.Web/Components/Pages/Channels/WhatsOnThisWeek.razor
@@ -45,7 +45,7 @@
 else if (_data is null || _data.TotalEvents == 0)
 {
     <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
-        No matched events found. Set groups to <strong>Auto-add all events</strong>, <strong>Auto-add populated</strong>, or <strong>Auto-add matching events</strong> with keywords to see results here.
+        No matched events found. Set groups to <strong>Auto-add all</strong>, <strong>Auto-add (guide data only)</strong>, or <strong>Auto-add matching</strong> with keywords to see results here.
     </MudAlert>
 }
 else


### PR DESCRIPTION
… policy labels matching the Group Settings drawer.